### PR TITLE
Close #27949: Add engagement notification for inactive users

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -71,6 +71,14 @@ nimbus-validation:
     settings-title:
       type: string
       description: The title of displayed in the Settings screen and app menu.
+re-engagement-notification:
+  description: A feature that shows the re-enagement notification if the user is inactive.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "If true, the re-engagement notification is shown to the inactive user."
 search-term-groups:
   description: A feature allowing the grouping of URLs around the search term that it came from.
   hasExposure: true

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -207,6 +207,32 @@ events:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/27780
     data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 122
+  re_engagement_notif_tapped:
+    type: event
+    description: |
+      User tapped on the re-engagement notification
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/27949
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/27978
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 122
+  re_engagement_notif_shown:
+    type: event
+    description: |
+      Re-engagement notification was shown to the user
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/27949
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/27978
+    data_sensitivity:
       - technical
     notification_emails:
       - android-probes@mozilla.com

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -103,6 +103,7 @@ import org.mozilla.fenix.library.historymetadata.HistoryMetadataGroupFragmentDir
 import org.mozilla.fenix.library.recentlyclosed.RecentlyClosedFragmentDirections
 import org.mozilla.fenix.onboarding.DefaultBrowserNotificationWorker
 import org.mozilla.fenix.onboarding.FenixOnboarding
+import org.mozilla.fenix.onboarding.ReEngagementNotificationWorker
 import org.mozilla.fenix.perf.MarkersActivityLifecycleCallbacks
 import org.mozilla.fenix.perf.MarkersFragmentLifecycleCallbacks
 import org.mozilla.fenix.perf.Performance
@@ -377,6 +378,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             components.appStore.dispatch(AppAction.ResumedMetricsAction)
 
             DefaultBrowserNotificationWorker.setDefaultBrowserNotificationIfNeeded(applicationContext)
+            ReEngagementNotificationWorker.setReEngagementNotificationIfNeeded(applicationContext)
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -261,6 +261,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         }
 
         subscribeToTabCollections()
+        updateLastBrowseActivity()
     }
 
     override fun onStop() {

--- a/app/src/main/java/org/mozilla/fenix/onboarding/MarketingNotificationHelper.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/MarketingNotificationHelper.kt
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.onboarding
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationManagerCompat
+import org.mozilla.fenix.GleanMetrics.Events.marketingNotificationAllowed
+import org.mozilla.fenix.R
+
+// Channel ID was not updated when it was renamed to marketing.  Thus, we'll have to continue
+// to use this ID as the marketing channel ID
+private const val MARKETING_CHANNEL_ID = "org.mozilla.fenix.default.browser.channel"
+
+// For notification that uses the marketing notification channel, IDs should be unique.
+const val DEFAULT_BROWSER_NOTIFICATION_ID = 1
+const val RE_ENGAGEMENT_NOTIFICATION_ID = 2
+
+/**
+ * Make sure the marketing notification channel exists.
+ *
+ * Returns the channel id to be used for notifications.
+ */
+fun ensureMarketingChannelExists(context: Context): String {
+    var channelEnabled = true
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val notificationManager: NotificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        var channel =
+            notificationManager.getNotificationChannel(MARKETING_CHANNEL_ID)
+
+        if (channel == null) {
+            channel = NotificationChannel(
+                MARKETING_CHANNEL_ID,
+                context.getString(R.string.notification_marketing_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            )
+
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        channelEnabled = channel.importance != NotificationManager.IMPORTANCE_NONE
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    val notificationsEnabled = try {
+        NotificationManagerCompat.from(context).areNotificationsEnabled()
+    } catch (e: Exception) {
+        false
+    }
+
+    marketingNotificationAllowed.set(notificationsEnabled && channelEnabled)
+
+    return MARKETING_CHANNEL_ID
+}

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -67,6 +67,8 @@
     <string name="pref_key_last_browse_activity_time" translatable="false">pref_key_last_browse_activity_time</string>
     <string name="pref_key_last_cfr_shown_time" translatable="false">pref_key_last_cfr_shown_time</string>
     <string name="pref_key_should_show_default_browser_notification" translatable="false">pref_key_should_show_default_browser_notification</string>
+    <string name="pref_key_re_engagement_notification_shown" translatable="false">pref_key_re_engagement_notification_shown</string>
+    <string name="pref_key_re_engagement_notification_enabled" translatable="false">pref_key_re_engagement_notification_enabled</string>
     <string name="pref_key_is_first_run" translatable="false">pref_key_is_first_run</string>
     <string name="pref_key_home_blocklist">pref_key_home_blocklist</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1072,6 +1072,11 @@
     <!-- Text shown in the notification that pops up to remind the user to set fenix as default browser.
     %1$s is a placeholder that will be replaced by the app name (Fenix). -->
     <string name="notification_default_browser_text">Make %1$s your default browser</string>
+    <!-- Title shown in the notification that pops up to re-engage the user -->
+    <string name="notification_re_engagement_title">Try private browsing</string>
+    <!-- Text shown in the notification that pops up to re-engage the user.
+    %1$s is a placeholder that will be replaced by the app name. -->
+    <string name="notification_re_engagement_text">Browse with no saved cookies or history in %1$s</string>
 
     <!-- Snackbar -->
     <!-- Text shown in snackbar when user deletes a collection -->

--- a/app/src/test/java/org/mozilla/fenix/home/intent/DefaultBrowserIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/DefaultBrowserIntentProcessorTest.kt
@@ -10,6 +10,7 @@ import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import mozilla.components.concept.engine.EngineSession
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertFalse
@@ -18,9 +19,12 @@ import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.onboarding.ReEngagementNotificationWorker
 
 @RunWith(FenixRobolectricTestRunner::class)
 class DefaultBrowserIntentProcessorTest {
@@ -60,6 +64,44 @@ class DefaultBrowserIntentProcessorTest {
         assert(result)
 
         assertNotNull(Events.defaultBrowserNotifTapped.testGetValue())
+        verify { navController wasNot Called }
+        verify { out wasNot Called }
+    }
+
+    @Test
+    fun `process re-engagement notification intents`() {
+        val navController: NavController = mockk(relaxed = true)
+        val out: Intent = mockk()
+        val activity: HomeActivity = mockk(relaxed = true)
+        val browsingModeManager: BrowsingModeManager = mockk(relaxed = true)
+
+        val intent = Intent().apply {
+            putExtra("org.mozilla.fenix.re-engagement.intent", true)
+        }
+        every { activity.applicationContext } returns testContext
+        every { activity.browsingModeManager } returns browsingModeManager
+
+        assertNull(Events.reEngagementNotifTapped.testGetValue())
+
+        val result = DefaultBrowserIntentProcessor(activity)
+            .process(intent, navController, out)
+
+        assert(result)
+
+        assertNotNull(Events.reEngagementNotifTapped.testGetValue())
+        verify {
+            activity.openToBrowserAndLoad(
+                searchTermOrURL = ReEngagementNotificationWorker.NOTIFICATION_TARGET_URL,
+                newTab = true,
+                from = BrowserDirection.FromGlobal,
+                customTabSessionId = null,
+                engine = null,
+                forceSearch = false,
+                flags = EngineSession.LoadUrlFlags.external(),
+                requestDesktopMode = false,
+                historyMetadata = null,
+            )
+        }
         verify { navController wasNot Called }
         verify { out wasNot Called }
     }

--- a/app/src/test/java/org/mozilla/fenix/onboarding/ReEngagementNotificationWorkerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/onboarding/ReEngagementNotificationWorkerTest.kt
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.onboarding
+
+import io.mockk.spyk
+import junit.framework.TestCase.assertFalse
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.utils.Settings
+
+@RunWith(FenixRobolectricTestRunner::class)
+class ReEngagementNotificationWorkerTest {
+    lateinit var settings: Settings
+
+    @Before
+    fun setUp() {
+        settings = Settings(testContext)
+    }
+
+    @Test
+    fun `GIVEN last browser activity THEN determine if the user is active correctly`() {
+        val localSetting = spyk(settings)
+
+        localSetting.lastBrowseActivity = System.currentTimeMillis()
+        assert(ReEngagementNotificationWorker.isActiveUser(localSetting))
+
+        localSetting.lastBrowseActivity = System.currentTimeMillis() - Settings.FOUR_HOURS_MS
+        assert(ReEngagementNotificationWorker.isActiveUser(localSetting))
+
+        localSetting.lastBrowseActivity = System.currentTimeMillis() - Settings.ONE_DAY_MS
+        assertFalse(ReEngagementNotificationWorker.isActiveUser(localSetting))
+
+        localSetting.lastBrowseActivity = 0
+        assertFalse(ReEngagementNotificationWorker.isActiveUser(localSetting))
+
+        localSetting.lastBrowseActivity = -1000
+        assertFalse(ReEngagementNotificationWorker.isActiveUser(localSetting))
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -769,6 +769,66 @@ class SettingsTest {
     }
 
     @Test
+    fun `GIVEN re-engagement notification shown and number of app launch THEN should set re-engagement notification returns correct value`() {
+        val localSetting = spyk(settings)
+
+        localSetting.reEngagementNotificationShown = false
+        localSetting.numberOfAppLaunches = 0
+        assert(localSetting.shouldSetReEngagementNotification())
+
+        localSetting.numberOfAppLaunches = 1
+        assert(localSetting.shouldSetReEngagementNotification())
+
+        localSetting.numberOfAppLaunches = 2
+        assertFalse(localSetting.shouldSetReEngagementNotification())
+
+        localSetting.reEngagementNotificationShown = true
+        localSetting.numberOfAppLaunches = 0
+        assertFalse(localSetting.shouldSetReEngagementNotification())
+    }
+
+    @Test
+    fun `GIVEN re-engagement notification shown and is default browser THEN should show re-engagement notification returns correct value`() {
+        val localSetting = spyk(settings)
+
+        every { localSetting.isDefaultBrowserBlocking() } returns false
+
+        every { localSetting.reEngagementNotificationEnabled } returns false
+        localSetting.reEngagementNotificationShown = false
+        assertFalse(localSetting.shouldShowReEngagementNotification())
+
+        every { localSetting.reEngagementNotificationEnabled } returns true
+        localSetting.reEngagementNotificationShown = false
+        assert(localSetting.shouldShowReEngagementNotification())
+
+        every { localSetting.reEngagementNotificationEnabled } returns false
+        localSetting.reEngagementNotificationShown = true
+        assertFalse(localSetting.shouldShowReEngagementNotification())
+
+        every { localSetting.reEngagementNotificationEnabled } returns true
+        localSetting.reEngagementNotificationShown = true
+        assertFalse(localSetting.shouldShowReEngagementNotification())
+
+        every { localSetting.isDefaultBrowserBlocking() } returns true
+
+        every { localSetting.reEngagementNotificationEnabled } returns false
+        localSetting.reEngagementNotificationShown = false
+        assertFalse(localSetting.shouldShowReEngagementNotification())
+
+        every { localSetting.reEngagementNotificationEnabled } returns true
+        localSetting.reEngagementNotificationShown = false
+        assertFalse(localSetting.shouldShowReEngagementNotification())
+
+        every { localSetting.reEngagementNotificationEnabled } returns false
+        localSetting.reEngagementNotificationShown = true
+        assertFalse(localSetting.shouldShowReEngagementNotification())
+
+        every { localSetting.reEngagementNotificationEnabled } returns true
+        localSetting.reEngagementNotificationShown = true
+        assertFalse(localSetting.shouldShowReEngagementNotification())
+    }
+
+    @Test
     fun inactiveTabsAreEnabled() {
         // When just created
         // Then

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -257,6 +257,14 @@ features:
         value:
           enabled: true
 
+  re-engagement-notification:
+    description: A feature that shows the re-enagement notification if the user is inactive.
+    variables:
+      enabled:
+        description: If true, the re-engagement notification is shown to the inactive user.
+        type: Boolean
+        default: true
+
 types:
   objects:
     MessageData:


### PR DESCRIPTION
This change:
- Adds a re-engagement notification for new users that is inactive after the first 24 hours.
- Moved default browser notification to 72 hours.
- Added Nimbus flag to A/B test re-engagement notification.
- Updated the default value of `lastBrowseActivity` to 0L.  It helps us finding out user that have never opened a new tab.  Also it is a better default to work with.

This change does not:
- Add Android 13 Notification opt-in.  This will be in a separate PR.

Manual test cases passed:
Inactive user and active user
- Installs and completes onboarding.
- Installs and sets Firefox to default browser.
- Installs and don't finish onboarding.
- Installs and force close the app.
- Installs and restarts phone after onboarding.
- Show home after user activity passes 4 hours.

Tests not completed yet:
- Nimbus flag.

This is a first run experiment.  We'll need QA to fully test this.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
Fixes #27949