### PR TITLE
For #28013 - Display correct hint for topic specific search engine

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -149,6 +149,13 @@ class ToolbarView(
                     Core.TABS_SEARCH_ENGINE_ID -> context.getString(R.string.tab_search_hint)
                     else -> context.getString(R.string.application_search_hint)
                 }
+            SearchEngine.Type.BUNDLED -> {
+                if (!searchEngine.isGeneral) {
+                    context.getString(R.string.application_search_hint)
+                } else {
+                    context.getString(R.string.search_hint)
+                }
+            }
             else ->
                 context.getString(R.string.search_hint)
         }

--- a/app/src/test/java/org/mozilla/fenix/search/toolbar/ToolbarViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/toolbar/ToolbarViewTest.kt
@@ -30,6 +30,7 @@ import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.search.SearchEngineSource
 import org.mozilla.fenix.search.SearchFragmentState
 import org.mozilla.fenix.utils.Settings
+import java.util.UUID
 
 @RunWith(FenixRobolectricTestRunner::class)
 class ToolbarViewTest {
@@ -49,6 +50,7 @@ class ToolbarViewTest {
                 every { name } returns "Search Engine"
                 every { icon } returns testContext.getDrawable(R.drawable.ic_search)!!.toBitmap()
                 every { type } returns SearchEngine.Type.BUNDLED
+                every { isGeneral } returns true
             },
         ),
         defaultEngine = null,
@@ -158,6 +160,67 @@ class ToolbarViewTest {
         verify { editToolbar.setIcon(any(), "Search Engine") }
     }
 
+    @Test
+    fun `GIVEN a general search engine is default WHEN a topic specific engine is selected THEN the hint changes`() {
+        val topicSpecificEngine = buildSearchEngine(SearchEngine.Type.BUNDLED, false)
+        val toolbarView = buildToolbarView(false)
+        toolbarView.update(defaultState)
+        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+
+        toolbarView.update(defaultState.copy(searchEngineSource = SearchEngineSource.Default(topicSpecificEngine)))
+
+        assertEquals(context.getString(R.string.application_search_hint), toolbarView.view.edit.hint)
+    }
+
+    @Test
+    fun `GIVEN a topic specific engine is default WHEN a general engine is selected THEN the hint changes`() {
+        val topicSpecificEngine = buildSearchEngine(SearchEngine.Type.BUNDLED, false)
+        val toolbarView = buildToolbarView(false)
+        toolbarView.update(defaultState.copy(searchEngineSource = SearchEngineSource.Default(topicSpecificEngine)))
+        assertEquals(context.getString(R.string.application_search_hint), toolbarView.view.edit.hint)
+
+        toolbarView.update(defaultState)
+
+        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+    }
+
+    @Test
+    fun `GIVEN a topic specific engine is default WHEN a custom engine is selected THEN the hint changes`() {
+        val topicSpecificEngine = buildSearchEngine(SearchEngine.Type.BUNDLED, false)
+        val customEngine = buildSearchEngine(SearchEngine.Type.CUSTOM, true)
+        val toolbarView = buildToolbarView(false)
+        toolbarView.update(defaultState.copy(searchEngineSource = SearchEngineSource.Default(topicSpecificEngine)))
+        assertEquals(context.getString(R.string.application_search_hint), toolbarView.view.edit.hint)
+
+        toolbarView.update(defaultState.copy(searchEngineSource = SearchEngineSource.Default(customEngine)))
+
+        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+    }
+
+    @Test
+    fun `GIVEN a general engine is default WHEN a custom engine is selected THEN the hint does not change`() {
+        val customEngine = buildSearchEngine(SearchEngine.Type.CUSTOM, true)
+        val toolbarView = buildToolbarView(false)
+        toolbarView.update(defaultState)
+        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+
+        toolbarView.update(defaultState.copy(searchEngineSource = SearchEngineSource.Default(customEngine)))
+
+        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+    }
+
+    @Test
+    fun `GIVEN a custom engine is default WHEN a general engine is selected THEN the hint does not change`() {
+        val customEngine = buildSearchEngine(SearchEngine.Type.CUSTOM, true)
+        val toolbarView = buildToolbarView(false)
+        toolbarView.update(defaultState.copy(searchEngineSource = SearchEngineSource.Default(customEngine)))
+        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+
+        toolbarView.update(defaultState)
+
+        assertEquals(context.getString(R.string.search_hint), toolbarView.view.edit.hint)
+    }
+
     private fun buildToolbarView(isPrivate: Boolean) = ToolbarView(
         context,
         Settings(context),
@@ -165,5 +228,13 @@ class ToolbarViewTest {
         isPrivate = isPrivate,
         view = toolbar,
         fromHomeFragment = false,
+    )
+
+    private fun buildSearchEngine(type: SearchEngine.Type, isGeneral: Boolean) = SearchEngine(
+        id = UUID.randomUUID().toString(),
+        name = "General",
+        icon = testContext.getDrawable(R.drawable.ic_search)!!.toBitmap(),
+        type = type,
+        isGeneral = isGeneral,
     )
 }


### PR DESCRIPTION
Since the search engines are split into two categories, general and topic specific, the hint for each category is different.

https://user-images.githubusercontent.com/32488956/207357078-11e2a516-8608-4636-90a1-12d60d9222d2.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
Fixes #28013