### PR TITLE
For #26736 - Fix add login username validation error state

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
@@ -195,8 +195,10 @@ class AddLoginFragment : Fragment(R.layout.fragment_add_login), MenuProvider {
 
         binding.usernameText.addTextChangedListener(
             object : TextWatcher {
-                override fun afterTextChanged(u: Editable?) {
-                    usernameChanged = true
+                override fun afterTextChanged(editable: Editable?) {
+                    // update usernameChanged to true when the text is not empty,
+                    // otherwise it is not changed, as this screen starts with an empty username.
+                    usernameChanged = editable.toString().isNotEmpty()
                     updateUsernameField()
                     setSaveButtonState()
                     findDuplicate()


### PR DESCRIPTION
## What
• Update validation to set usernameChanged flag to false if the username is empty since this screen starts with an empty username.
• I couldn't take visible screenshots for this screen, could someone please share how to enable screenshots for saved logins functionality?


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #26736