### PR TITLE
Update protobuf to version 3.21.10

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -59,7 +59,7 @@ object Versions {
 
     const val google_play_review_version = "2.0.0"
 
-    const val protobuf = "3.21.7" // keep in sync with the version used in AS.
+    const val protobuf = "3.21.10" // keep in sync with the version used in AS.
 }
 
 @Suppress("unused")


### PR DESCRIPTION
A-S 96.1.1 is bringing an updated protobuf version in with it. We should keep Fenix in sync. Relevant changelogs (not all releases affect the Java code):
* https://github.com/protocolbuffers/protobuf/releases/tag/v21.8
* https://github.com/protocolbuffers/protobuf/releases/tag/v21.10