### PR TITLE
For #28090: Show QR scanner for general or custom search engine

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -811,7 +811,10 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
     }
 
     private fun updateQrButton(searchFragmentState: SearchFragmentState) {
-        when (searchFragmentState.searchEngineSource.searchEngine == searchFragmentState.defaultEngine) {
+        val searchEngine = searchFragmentState.searchEngineSource.searchEngine
+        when (
+            searchEngine?.isGeneral == true || searchEngine?.type == SearchEngine.Type.CUSTOM
+        ) {
             true -> {
                 if (qrButtonAction == null) {
                     qrButtonAction = IncreasedTapAreaActionDecorator(


### PR DESCRIPTION
The implementation for now is a hardcoded, since we do not have a clear separation between "general" search engines and "topic specific" search engines. When that patch lands, this PR will require modifications. Needs https://github.com/mozilla-mobile/firefox-android/pull/273

Expected behavior:

https://user-images.githubusercontent.com/32488956/205978715-7aa21a3e-f462-4598-af04-1adde18c1ca5.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #28090