### PR TITLE
Close #27949: Add Nimbus exposure event for re-engagement notification

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/onboarding/ReEngagementNotificationWorker.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/ReEngagementNotificationWorker.kt
@@ -23,6 +23,7 @@ import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.nimbus.FxNimbus
 import org.mozilla.fenix.utils.IntentUtils
 import org.mozilla.fenix.utils.Settings
 import java.util.concurrent.TimeUnit
@@ -39,6 +40,14 @@ class ReEngagementNotificationWorker(
         val settings = applicationContext.settings()
 
         if (isActiveUser(settings) || !settings.shouldShowReEngagementNotification()) {
+            return Result.success()
+        }
+
+        // Recording the exposure event here to capture all users who met all criteria to receive
+        // the re-engagement notification
+        FxNimbus.features.reEngagementNotification.recordExposure()
+
+        if (!settings.reEngagementNotificationEnabled) {
             return Result.success()
         }
 

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -599,7 +599,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      * Check if we should show the re-engagement notification.
      */
     fun shouldShowReEngagementNotification(): Boolean {
-        return !reEngagementNotificationShown && reEngagementNotificationEnabled && !isDefaultBrowserBlocking()
+        return !reEngagementNotificationShown && !isDefaultBrowserBlocking()
     }
 
     /**

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -793,37 +793,17 @@ class SettingsTest {
 
         every { localSetting.isDefaultBrowserBlocking() } returns false
 
-        every { localSetting.reEngagementNotificationEnabled } returns false
-        localSetting.reEngagementNotificationShown = false
-        assertFalse(localSetting.shouldShowReEngagementNotification())
-
-        every { localSetting.reEngagementNotificationEnabled } returns true
         localSetting.reEngagementNotificationShown = false
         assert(localSetting.shouldShowReEngagementNotification())
 
-        every { localSetting.reEngagementNotificationEnabled } returns false
-        localSetting.reEngagementNotificationShown = true
-        assertFalse(localSetting.shouldShowReEngagementNotification())
-
-        every { localSetting.reEngagementNotificationEnabled } returns true
         localSetting.reEngagementNotificationShown = true
         assertFalse(localSetting.shouldShowReEngagementNotification())
 
         every { localSetting.isDefaultBrowserBlocking() } returns true
 
-        every { localSetting.reEngagementNotificationEnabled } returns false
         localSetting.reEngagementNotificationShown = false
         assertFalse(localSetting.shouldShowReEngagementNotification())
 
-        every { localSetting.reEngagementNotificationEnabled } returns true
-        localSetting.reEngagementNotificationShown = false
-        assertFalse(localSetting.shouldShowReEngagementNotification())
-
-        every { localSetting.reEngagementNotificationEnabled } returns false
-        localSetting.reEngagementNotificationShown = true
-        assertFalse(localSetting.shouldShowReEngagementNotification())
-
-        every { localSetting.reEngagementNotificationEnabled } returns true
         localSetting.reEngagementNotificationShown = true
         assertFalse(localSetting.shouldShowReEngagementNotification())
     }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #27949