### PR TITLE
For #28098 - Disable openPocketDiscoverMoreTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -279,6 +279,7 @@ class HomeScreenTest {
         }
     }
 
+    @Ignore("Failed, see: https://github.com/mozilla-mobile/fenix/issues/28098")
     @Test
     fun openPocketDiscoverMoreTest() {
         activityTestRule.activityRule.applySettingsExceptions {


### PR DESCRIPTION
#28098 `openPocketDiscoverMoreTest` starting to fail recently, likely same problem as https://github.com/mozilla-mobile/fenix/issues/28069

Fixes #28098