### PR TITLE
Bug 1804107 - Fixed configuration change crash when BrowserFragment UI not initialized

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -33,7 +33,6 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
@@ -1400,6 +1399,11 @@ abstract class BaseBrowserFragment :
         binding.swipeRefresh.isEnabled = shouldPullToRefreshBeEnabled(inFullScreen)
     }
 
+    @CallSuper
+    internal open fun onUpdateToolbarForConfigurationChange(toolbar: BrowserToolbarView) {
+        toolbar.dismissMenu()
+    }
+
     /*
      * Dereference these views when the fragment view is destroyed to prevent memory leaks
      */
@@ -1472,7 +1476,9 @@ abstract class BaseBrowserFragment :
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
 
-        _browserToolbarView?.dismissMenu()
+        _browserToolbarView?.let {
+            onUpdateToolbarForConfigurationChange(it)
+        }
     }
 
     // This method is called in response to native web extension messages from

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.browser
 
 import android.content.Context
-import android.content.res.Configuration
 import android.os.StrictMode
 import android.view.View
 import android.view.ViewGroup
@@ -32,6 +31,7 @@ import org.mozilla.fenix.GleanMetrics.ReaderMode
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.TabCollectionStorage
+import org.mozilla.fenix.components.toolbar.BrowserToolbarView
 import org.mozilla.fenix.components.toolbar.ToolbarMenu
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
@@ -90,7 +90,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
 
         browserToolbarView.view.addNavigationAction(homeAction)
 
-        setScreenSize(isTablet = resources.getBoolean(R.bool.tablet))
+        updateToolbarActions(isTablet = resources.getBoolean(R.bool.tablet))
 
         val readerModeAction =
             BrowserToolbar.ToggleButton(
@@ -170,7 +170,14 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         }
     }
 
-    private fun setScreenSize(isTablet: Boolean) {
+    override fun onUpdateToolbarForConfigurationChange(toolbar: BrowserToolbarView) {
+        super.onUpdateToolbarForConfigurationChange(toolbar)
+
+        updateToolbarActions(isTablet = resources.getBoolean(R.bool.tablet))
+    }
+
+    @VisibleForTesting
+    internal fun updateToolbarActions(isTablet: Boolean) {
         if (isTablet == this.isTablet) return
 
         if (isTablet) {
@@ -280,6 +287,8 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         refreshAction?.let {
             browserToolbarView.view.addNavigationAction(it)
         }
+
+        browserToolbarView.view.invalidateActions()
     }
 
     private fun removeTabletActions() {
@@ -292,6 +301,8 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         refreshAction?.let {
             browserToolbarView.view.removeNavigationAction(it)
         }
+
+        browserToolbarView.view.invalidateActions()
     }
 
     override fun onStart() {
@@ -446,10 +457,5 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     @VisibleForTesting
     internal fun updateLastBrowseActivity() {
         requireContext().settings().lastBrowseActivity = System.currentTimeMillis()
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        setScreenSize(isTablet = resources.getBoolean(R.bool.tablet))
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/browser/BrowserFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/BrowserFragmentTest.kt
@@ -313,6 +313,21 @@ class BrowserFragmentTest {
     }
 
     @Test
+    fun `WHEN toolbar is initialized THEN onConfigurationChanged sets toolbar actions for size in fragment`() {
+        val browserToolbarView: BrowserToolbarView = mockk(relaxed = true)
+
+        browserFragment._browserToolbarView = null
+        browserFragment.onConfigurationChanged(mockk(relaxed = true))
+        verify(exactly = 0) { browserFragment.onUpdateToolbarForConfigurationChange(any()) }
+        verify(exactly = 0) { browserFragment.updateToolbarActions(any()) }
+
+        browserFragment._browserToolbarView = browserToolbarView
+        browserFragment.onConfigurationChanged(mockk(relaxed = true))
+        verify(exactly = 1) { browserFragment.onUpdateToolbarForConfigurationChange(any()) }
+        verify(exactly = 1) { browserFragment.updateToolbarActions(any()) }
+    }
+
+    @Test
     fun `WHEN fragment configuration changed THEN menu is dismissed`() {
         val browserToolbarView: BrowserToolbarView = mockk(relaxed = true)
         every { browserFragment.context } returns null
@@ -325,7 +340,9 @@ class BrowserFragmentTest {
 
     @Test
     fun `WHEN fragment configuration screen size changes between tablet and mobile size THEN tablet action items added and removed`() {
+        val browserToolbarView: BrowserToolbarView = mockk(relaxed = true)
         val browserToolbar: BrowserToolbar = mockk(relaxed = true)
+        browserFragment._browserToolbarView = browserToolbarView
         every { browserFragment.browserToolbarView.view } returns browserToolbar
 
         mockkObject(ThemeManager.Companion)
@@ -348,7 +365,9 @@ class BrowserFragmentTest {
 
     @Test
     fun `WHEN fragment configuration change enables tablet size twice THEN tablet action items are only added once`() {
+        val browserToolbarView: BrowserToolbarView = mockk(relaxed = true)
         val browserToolbar: BrowserToolbar = mockk(relaxed = true)
+        browserFragment._browserToolbarView = browserToolbarView
         every { browserFragment.browserToolbarView.view } returns browserToolbar
 
         mockkObject(ThemeManager.Companion)
@@ -370,7 +389,9 @@ class BrowserFragmentTest {
 
     @Test
     fun `WHEN fragment configuration change sets mobile size twice THEN tablet action items are not added or removed`() {
+        val browserToolbarView: BrowserToolbarView = mockk(relaxed = true)
         val browserToolbar: BrowserToolbar = mockk(relaxed = true)
+        browserFragment._browserToolbarView = browserToolbarView
         every { browserFragment.browserToolbarView.view } returns browserToolbar
 
         mockkObject(ThemeManager.Companion)


### PR DESCRIPTION
To fix [Bugzilla 1804107](https://bugzilla.mozilla.org/show_bug.cgi?id=1804107) for when the BrowserFragment configuration change occurs before the UI has been drawn and the toolbar has been initialized (still null). 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27540