### PR TITLE
For #3722: Invoke search on long press home button

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -90,6 +90,7 @@ import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.setNavigationIcon
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.HomeFragmentDirections
+import org.mozilla.fenix.home.intent.AssistIntentProcessor
 import org.mozilla.fenix.home.intent.CrashReporterIntentProcessor
 import org.mozilla.fenix.home.intent.DefaultBrowserIntentProcessor
 import org.mozilla.fenix.home.intent.HomeDeepLinkIntentProcessor
@@ -182,6 +183,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         listOf(
             HomeDeepLinkIntentProcessor(this),
             SpeechProcessingIntentProcessor(this, components.core.store),
+            AssistIntentProcessor(),
             StartSearchIntentProcessor(),
             OpenBrowserIntentProcessor(this, ::getIntentSessionId),
             OpenSpecificTabIntentProcessor(this),

--- a/app/src/main/java/org/mozilla/fenix/home/intent/AssistIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/AssistIntentProcessor.kt
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.intent
+
+import android.content.Intent
+import androidx.navigation.NavController
+import androidx.navigation.navOptions
+import org.mozilla.fenix.NavGraphDirections
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.metrics.MetricsUtils
+import org.mozilla.fenix.ext.nav
+
+/**
+ * Long pressing home button should also open to the search fragment if Fenix is set as the
+ * assist app
+ */
+class AssistIntentProcessor : HomeIntentProcessor {
+    override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
+        if (intent.action != Intent.ACTION_ASSIST) {
+            return false
+        }
+
+        val directions = NavGraphDirections.actionGlobalSearchDialog(
+            sessionId = null,
+            // Will follow this up with adding `ASSIST` as a search source.
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=1808043
+            searchAccessPoint = MetricsUtils.Source.NONE,
+        )
+
+        val options = navOptions {
+            popUpTo(R.id.homeFragment)
+        }
+
+        navController.nav(null, directions, options)
+
+        return true
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/home/intent/AssistIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/AssistIntentProcessorTest.kt
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.intent
+
+import android.content.Intent
+import androidx.navigation.NavController
+import androidx.navigation.navOptions
+import io.mockk.Called
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.NavGraphDirections
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.metrics.MetricsUtils
+import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+
+@RunWith(FenixRobolectricTestRunner::class)
+class AssistIntentProcessorTest {
+    private val navController: NavController = mockk(relaxed = true)
+    private val out: Intent = mockk(relaxed = true)
+
+    @Test
+    fun `GIVEN an intent with wrong action WHEN it is processed THEN nothing should happen`() {
+        val intent = Intent().apply {
+            action = TEST_WRONG_ACTION
+        }
+        val result = StartSearchIntentProcessor().process(intent, navController, out)
+
+        verify { navController wasNot Called }
+        verify { out wasNot Called }
+        assertFalse(result)
+    }
+
+    @Test
+    fun `GIVEN an intent with ACTION_ASSIST action WHEN it is processed THEN navigate to the search dialog`() {
+        val intent = Intent().apply {
+            action = Intent.ACTION_ASSIST
+        }
+
+        AssistIntentProcessor().process(intent, navController, out)
+        val options = navOptions {
+            popUpTo(R.id.homeFragment)
+        }
+
+        verify {
+            navController.nav(
+                null,
+                NavGraphDirections.actionGlobalSearchDialog(
+                    sessionId = null,
+                    searchAccessPoint = MetricsUtils.Source.NONE,
+                ),
+                options,
+            )
+        }
+
+        verify { out wasNot Called }
+    }
+
+    companion object {
+        const val TEST_WRONG_ACTION = "test-action"
+    }
+}


### PR DESCRIPTION
When opening Fenix as an assistance, automatically take them to search.

Co-authored-by: s-ankur <s.ankursonawane@gmail.com>

![2022-12-06 13 45 14](https://user-images.githubusercontent.com/1250545/206032761-cffea2ee-9c0f-4df1-94b5-923f47928920.gif)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #3722