### PR TITLE
For #25812 - Set the cursor at the end for search terms when switching to toolbar editMode

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -12,6 +12,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.concept.toolbar.Toolbar
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import mozilla.components.support.ktx.android.view.hideKeyboard
@@ -135,7 +136,12 @@ class ToolbarView(
             // we have the most up to date text
             interactor.onTextChanged(view.url.toString())
 
-            view.editMode()
+            // If search terms are displayed, move the cursor to the end instead of selecting all text.
+            if (settings.showUnifiedSearchFeature && searchState.searchTerms.isNotBlank()) {
+                view.editMode(cursorPlacement = Toolbar.CursorPlacement.END)
+            } else {
+                view.editMode()
+            }
             isInitialized = true
         }
 


### PR DESCRIPTION
Set the cursor at the end of the search terms when switching to `editMode`.
Fenix counterpart of https://github.com/mozilla-mobile/firefox-android/pull/265

https://user-images.githubusercontent.com/35462038/206451770-149c8ddb-277e-44c2-b651-66685f3275e2.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #25812