### PR TITLE
For #28133 - Fix Pocket story category color mismatch

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
@@ -479,10 +479,10 @@ data class PocketStoriesCategoryColors(
          */
         @Composable
         fun buildColors(
-            selectedBackgroundColor: Color = FirefoxTheme.colors.textActionPrimary,
-            unselectedBackgroundColor: Color = FirefoxTheme.colors.textActionTertiary,
-            selectedTextColor: Color = FirefoxTheme.colors.actionPrimary,
-            unselectedTextColor: Color = FirefoxTheme.colors.actionTertiary,
+            selectedBackgroundColor: Color = FirefoxTheme.colors.actionPrimary,
+            unselectedBackgroundColor: Color = FirefoxTheme.colors.actionTertiary,
+            selectedTextColor: Color = FirefoxTheme.colors.textActionPrimary,
+            unselectedTextColor: Color = FirefoxTheme.colors.textActionTertiary,
         ) = PocketStoriesCategoryColors(
             selectedBackgroundColor = selectedBackgroundColor,
             unselectedBackgroundColor = unselectedBackgroundColor,


### PR DESCRIPTION
| Before | After |
| - | - |
| <img src="https://user-images.githubusercontent.com/87384386/206544559-4691adb0-e0d7-4578-8518-9befef5832e2.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/206546984-4e1473a7-365a-425f-a621-e43ed2647a1e.png" width=300/> |


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #28133