### PR TITLE
For #28093 - Try to show Nimbus messages after the messages are loaded

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddleware.kt
@@ -40,6 +40,12 @@ class MessagingMiddleware(
                 coroutineScope.launch {
                     val messages = messagingStorage.getMessages()
                     context.store.dispatch(UpdateMessages(messages))
+                    // It may be that the first `Evaluate` from `MessagingFeature` was dispatched
+                    // before the messages were loaded based on the `Restore` action and so
+                    // it won't lead to messages being shown because none were loaded.
+                    // Calling `Evaluate` again after the messages are loaded based on the `Restore` action
+                    // will ensure the newly made available messages will be shown.
+                    context.store.dispatch(Evaluate)
                 }
             }
 


### PR DESCRIPTION
Currently the `Evaluate` action to try showing Nimbus messages is dispatched from `MessagingFeature` when the app's `onStart` method is called - and the application is visible.
The `Restore` action which would load the available messages is dispatched based on a callback that although is set when the app is opened it was seen in manual tests that it could fire after app's `onStart` and as such the loaded messages would not be tried to be shown.

Adding a new call to evaluate messages after we know they are loaded will ensure they will be shown as soon as possible.

The race condition between loading messages and trying to show them is resolved in version 109 of the app (current app version) by switching from a callback system for knowing when the Nimbus configuration is done to having all needed operations run on `Main` in application's `onCreate` making the data available to when later `MessagingFeature` tries to show the next available message.

Video showing the survey appearing on a local build of 108 with this patch applied:


https://user-images.githubusercontent.com/11428869/206699060-9372b8e6-ad66-4a38-87e9-3e6673cd05ad.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
