### PR TITLE
For #23841: Hide keyboard when selecting month or year

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorFragment.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.settings.creditcards
 
 import android.content.DialogInterface
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
@@ -56,6 +57,7 @@ class CreditCardEditorFragment :
 
     private lateinit var interactor: CreditCardEditorInteractor
 
+    @SuppressLint("ClickableViewAccessibility")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -81,10 +83,20 @@ class CreditCardEditorFragment :
             creditCardEditorView = CreditCardEditorView(binding, interactor)
             creditCardEditorView.bind(creditCardEditorState)
 
-            binding.cardNumberInput.apply {
-                requestFocus()
-                placeCursorAtEnd()
-                showKeyboard()
+            binding.apply {
+                cardNumberInput.apply {
+                    requestFocus()
+                    placeCursorAtEnd()
+                    showKeyboard()
+                }
+                expiryMonthDropDown.setOnTouchListener { view, _ ->
+                    view?.hideKeyboard()
+                    false
+                }
+                expiryYearDropDown.setOnTouchListener { view, _ ->
+                    view?.hideKeyboard()
+                    false
+                }
             }
         }
     }


### PR DESCRIPTION
CI for https://github.com/sunilk9211/fenix/tree/23841-credit_cards

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #23841