### PR TITLE
Bug 1804274: Adds entrypoints to firefox accounts interactions

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/GlobalDirections.kt
+++ b/app/src/main/java/org/mozilla/fenix/GlobalDirections.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix
 
 import androidx.navigation.NavDirections
 import mozilla.appservices.places.BookmarkRoot
+import mozilla.components.concept.sync.FxAEntrypoint
 
 /**
  * Used with [HomeActivity] global navigation to indicate which fragment is being opened.
@@ -28,7 +29,7 @@ enum class GlobalDirections(val navDirections: NavDirections, val destinationId:
         R.id.settingsFragment,
     ),
     Sync(
-        NavGraphDirections.actionGlobalTurnOnSync(),
+        NavGraphDirections.actionGlobalTurnOnSync(entrypoint = FxAEntrypoint.DeepLink),
         R.id.turnOnSyncFragment,
     ),
     SearchEngine(

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
@@ -22,6 +22,7 @@ import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineSession.LoadUrlFlags
 import mozilla.components.concept.engine.prompt.ShareData
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.top.sites.DefaultTopSitesStorage
 import mozilla.components.feature.top.sites.PinnedSiteStorage
@@ -231,9 +232,9 @@ class DefaultBrowserToolbarMenuController(
                     AccountState.AUTHENTICATED ->
                         BrowserFragmentDirections.actionGlobalAccountSettingsFragment()
                     AccountState.NEEDS_REAUTHENTICATION ->
-                        BrowserFragmentDirections.actionGlobalAccountProblemFragment()
+                        BrowserFragmentDirections.actionGlobalAccountProblemFragment(entrypoint = FxAEntrypoint.BrowserToolbar)
                     AccountState.NO_ACCOUNT ->
-                        BrowserFragmentDirections.actionGlobalTurnOnSync()
+                        BrowserFragmentDirections.actionGlobalTurnOnSync(entrypoint = FxAEntrypoint.BrowserToolbar)
                 }
                 browserAnimator.captureEngineViewAndDrawStatically {
                     navController.nav(

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenuBuilder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenuBuilder.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.menu.view.MenuButton
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.service.glean.private.NoExtras
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.Config
@@ -43,6 +44,7 @@ import org.mozilla.fenix.GleanMetrics.HomeMenu as HomeMenuMetrics
  * @property menuButton The [MenuButton] that will be used to create a menu when the button is
  * clicked.
  * @property hideOnboardingIfNeeded Lambda invoked to dismiss onboarding.
+ * @property fxaEntrypoint the entrypoint if we need to authenticate, it will be reported in telemetry
  */
 @Suppress("LongParameterList")
 class HomeMenuBuilder(
@@ -53,6 +55,7 @@ class HomeMenuBuilder(
     private val navController: NavController,
     private val menuButton: WeakReference<MenuButton>,
     private val hideOnboardingIfNeeded: () -> Unit,
+    private val fxaEntrypoint: FxAEntrypoint = FxAEntrypoint.HomeMenu,
 ) {
 
     /**
@@ -109,9 +112,9 @@ class HomeMenuBuilder(
                         AccountState.AUTHENTICATED ->
                             HomeFragmentDirections.actionGlobalAccountSettingsFragment()
                         AccountState.NEEDS_REAUTHENTICATION ->
-                            HomeFragmentDirections.actionGlobalAccountProblemFragment()
+                            HomeFragmentDirections.actionGlobalAccountProblemFragment(entrypoint = fxaEntrypoint)
                         AccountState.NO_ACCOUNT ->
-                            HomeFragmentDirections.actionGlobalTurnOnSync()
+                            HomeFragmentDirections.actionGlobalTurnOnSync(entrypoint = fxaEntrypoint)
                     },
                 )
             }
@@ -181,7 +184,7 @@ class HomeMenuBuilder(
             HomeMenu.Item.ReconnectSync -> {
                 navController.nav(
                     R.id.homeFragment,
-                    HomeFragmentDirections.actionGlobalAccountProblemFragment(),
+                    HomeFragmentDirections.actionGlobalAccountProblemFragment(entrypoint = fxaEntrypoint),
                 )
             }
             HomeMenu.Item.Extensions -> {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingManualSignInViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingManualSignInViewHolder.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding
 import android.view.View
 import androidx.navigation.Navigation
 import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.service.glean.private.NoExtras
 import org.mozilla.fenix.GleanMetrics.Onboarding
 import org.mozilla.fenix.R
@@ -20,7 +21,7 @@ class OnboardingManualSignInViewHolder(view: View) : RecyclerView.ViewHolder(vie
         binding.fxaSignInButton.setOnClickListener {
             Onboarding.fxaManualSignin.record(NoExtras())
 
-            val directions = HomeFragmentDirections.actionGlobalTurnOnSync()
+            val directions = HomeFragmentDirections.actionGlobalTurnOnSync(entrypoint = FxAEntrypoint.OnboardingManualSignIn)
             Navigation.findNavController(view).navigate(directions)
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
@@ -10,6 +10,7 @@ import androidx.core.view.isVisible
 import androidx.navigation.NavController
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.concept.storage.BookmarkNode
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.support.base.feature.UserInteractionHandler
 import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.R
@@ -140,7 +141,7 @@ class BookmarkView(
             adapter = bookmarkAdapter
         }
         binding.bookmarkFoldersSignIn.setOnClickListener {
-            navController.navigate(NavGraphDirections.actionGlobalTurnOnSync())
+            navController.navigate(NavGraphDirections.actionGlobalTurnOnSync(entrypoint = FxAEntrypoint.BookmarkView))
         }
         binding.swipeRefresh.setOnRefreshListener {
             interactor.onRequestSync()

--- a/app/src/main/java/org/mozilla/fenix/onboarding/HomeOnboardingDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/HomeOnboardingDialogFragment.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.DialogFragment
 import androidx.navigation.fragment.findNavController
 import com.google.accompanist.insets.ProvideWindowInsets
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.components
@@ -58,7 +59,7 @@ class HomeOnboardingDialogFragment : DialogFragment() {
                         onSignInButtonClick = {
                             findNavController().nav(
                                 R.id.homeOnboardingDialogFragment,
-                                HomeOnboardingDialogFragmentDirections.actionGlobalTurnOnSync(),
+                                HomeOnboardingDialogFragmentDirections.actionGlobalTurnOnSync(entrypoint = FxAEntrypoint.HomeOnboardingDialog),
                             )
                             onDismiss()
                         },

--- a/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
@@ -14,6 +14,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import mozilla.components.feature.qr.QrFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
@@ -22,7 +23,8 @@ import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 
-class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
+class PairFragment() : Fragment(R.layout.fragment_pair), UserInteractionHandler {
+    private val args by navArgs<PairFragmentArgs>()
 
     private val qrFeature = ViewBoundFeatureWrapper<QrFeature>()
 
@@ -51,6 +53,7 @@ class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
                     requireComponents.services.accountsAuthFeature.beginPairingAuthentication(
                         requireContext(),
                         pairingUrl,
+                        args.entrypoint,
                     )
                     val vibrator = requireContext().getSystemService<Vibrator>()!!
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
 import mozilla.components.service.glean.private.NoExtras
@@ -256,7 +257,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
         val directions: NavDirections? = when (preference.key) {
             resources.getString(R.string.pref_key_sign_in) -> {
-                SettingsFragmentDirections.actionSettingsFragmentToTurnOnSyncFragment()
+                SettingsFragmentDirections.actionSettingsFragmentToTurnOnSyncFragment(entrypoint = FxAEntrypoint.SettingsMenu)
             }
             resources.getString(R.string.pref_key_tabs) -> {
                 SettingsFragmentDirections.actionSettingsFragmentToTabsSettingsFragment()
@@ -338,7 +339,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 SettingsFragmentDirections.actionSettingsFragmentToAccountSettingsFragment()
             }
             resources.getString(R.string.pref_key_account_auth_error) -> {
-                SettingsFragmentDirections.actionSettingsFragmentToAccountProblemFragment()
+                SettingsFragmentDirections.actionSettingsFragmentToAccountProblemFragment(entrypoint = FxAEntrypoint.SettingsMenu)
             }
             resources.getString(R.string.pref_key_delete_browsing_data) -> {
                 SettingsFragmentDirections.actionSettingsFragmentToDeleteBrowsingDataFragment()

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountProblemFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountProblemFragment.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.settings.account
 import android.os.Bundle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import kotlinx.coroutines.Dispatchers
@@ -22,10 +23,11 @@ import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.showToolbar
 
-class AccountProblemFragment : PreferenceFragmentCompat(), AccountObserver {
+class AccountProblemFragment() : PreferenceFragmentCompat(), AccountObserver {
+    private val args by navArgs<AccountProblemFragmentArgs>()
 
     private val signInClickListener = Preference.OnPreferenceClickListener {
-        requireComponents.services.accountsAuthFeature.beginAuthentication(requireContext())
+        requireComponents.services.accountsAuthFeature.beginAuthentication(requireContext(), args.entrypoint)
         SyncAuth.useEmailProblem.record(NoExtras())
         // TODO The sign-in web content populates session history,
         // so pressing "back" after signing in won't take us back into the settings screen, but rather up the

--- a/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
@@ -62,7 +62,8 @@ class TurnOnSyncFragment : Fragment(), AccountObserver {
     private val binding get() = _binding!!
 
     private fun navigateToPairFragment() {
-        val directions = TurnOnSyncFragmentDirections.actionTurnOnSyncFragmentToPairFragment()
+        // we pass the entrypoint along to the pair fragment
+        val directions = TurnOnSyncFragmentDirections.actionTurnOnSyncFragmentToPairFragment(entrypoint = args.entrypoint)
         requireView().findNavController().navigate(directions)
         SyncAuth.scanPairing.record(NoExtras())
     }
@@ -168,7 +169,7 @@ class TurnOnSyncFragment : Fragment(), AccountObserver {
     }
 
     private fun navigateToPairWithEmail() {
-        requireComponents.services.accountsAuthFeature.beginAuthentication(requireContext())
+        requireComponents.services.accountsAuthFeature.beginAuthentication(requireContext(), args.entrypoint)
         SyncAuth.useEmail.record(NoExtras())
         // TODO The sign-in web content populates session history,
         // so pressing "back" after signing in won't take us back into the settings screen, but rather up the

--- a/app/src/main/java/org/mozilla/fenix/settings/autofill/AutofillSettingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/autofill/AutofillSettingFragment.kt
@@ -23,6 +23,7 @@ import androidx.preference.SwitchPreference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.sync.autofill.AutofillCreditCardsAddressesStorage
@@ -164,12 +165,12 @@ class AutofillSettingFragment : BiometricPromptPreferenceFragment() {
                 .getString(R.string.preferences_credit_cards_sync_cards),
             onSyncSignInClicked = {
                 findNavController().navigate(
-                    NavGraphDirections.actionGlobalTurnOnSync(),
+                    NavGraphDirections.actionGlobalTurnOnSync(entrypoint = FxAEntrypoint.AutofillSetting),
                 )
             },
             onReconnectClicked = {
                 findNavController().navigate(
-                    AutofillSettingFragmentDirections.actionGlobalAccountProblemFragment(),
+                    AutofillSettingFragmentDirections.actionGlobalAccountProblemFragment(entrypoint = FxAEntrypoint.AutofillSetting),
                 )
             },
         )

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
@@ -22,6 +22,7 @@ import androidx.preference.SwitchPreference
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.feature.autofill.preference.AutofillPreference
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.glean.private.NoExtras
@@ -148,12 +149,12 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat() {
                 .getString(R.string.preferences_passwords_sync_logins),
             onSyncSignInClicked = {
                 val directions =
-                    SavedLoginsAuthFragmentDirections.actionSavedLoginsAuthFragmentToTurnOnSyncFragment()
+                    SavedLoginsAuthFragmentDirections.actionSavedLoginsAuthFragmentToTurnOnSyncFragment(entrypoint = FxAEntrypoint.SavedLogins)
                 findNavController().navigate(directions)
             },
             onReconnectClicked = {
                 val directions =
-                    SavedLoginsAuthFragmentDirections.actionGlobalAccountProblemFragment()
+                    SavedLoginsAuthFragmentDirections.actionGlobalAccountProblemFragment(entrypoint = FxAEntrypoint.SavedLogins)
                 findNavController().navigate(directions)
             },
         )

--- a/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.concept.sync.Device
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.concept.sync.TabData
 import mozilla.components.feature.accounts.push.SendTabUseCases
 import mozilla.components.feature.session.SessionUseCases
@@ -73,6 +74,7 @@ interface ShareController {
  * @param sendTabUseCases instance of [SendTabUseCases] which allows sending tabs to account devices.
  * @param snackbar - instance of [FenixSnackbar] for displaying styled snackbars
  * @param navController - [NavController] used for navigation.
+ * @param fxaEntrypoint - the entrypoint if we need to authenticate, it will be reported in telemetry
  * @param dismiss - callback signalling sharing can be closed.
  */
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -87,11 +89,12 @@ class DefaultShareController(
     private val recentAppsStorage: RecentAppsStorage,
     private val viewLifecycleScope: CoroutineScope,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val fxaEntrypoint: FxAEntrypoint = FxAEntrypoint.ShareMenu,
     private val dismiss: (ShareController.Result) -> Unit,
 ) : ShareController {
 
     override fun handleReauth() {
-        val directions = ShareFragmentDirections.actionGlobalAccountProblemFragment()
+        val directions = ShareFragmentDirections.actionGlobalAccountProblemFragment(entrypoint = fxaEntrypoint)
         navController.nav(R.id.shareFragment, directions)
         dismiss(ShareController.Result.DISMISSED)
     }
@@ -161,7 +164,7 @@ class DefaultShareController(
     override fun handleSignIn() {
         SyncAccount.signInToSendTab.record(NoExtras())
         val directions =
-            ShareFragmentDirections.actionGlobalTurnOnSync(padSnackbar = true)
+            ShareFragmentDirections.actionGlobalTurnOnSync(padSnackbar = true, entrypoint = fxaEntrypoint)
         navController.nav(R.id.shareFragment, directions)
         dismiss(ShareController.Result.DISMISSED)
     }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
@@ -13,6 +13,7 @@ import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.prompt.ShareData
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.glean.private.NoExtras
 import org.mozilla.fenix.BrowserDirection
@@ -127,7 +128,7 @@ class DefaultNavigationInteractor(
         val direction = if (isSignedIn) {
             TabsTrayFragmentDirections.actionGlobalAccountSettingsFragment()
         } else {
-            TabsTrayFragmentDirections.actionGlobalTurnOnSync()
+            TabsTrayFragmentDirections.actionGlobalTurnOnSync(entrypoint = FxAEntrypoint.NavigationInteraction)
         }
         navController.navigate(direction)
     }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/ext/SyncedTabsViewErrorType.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/ext/SyncedTabsViewErrorType.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.tabstray.ext
 
 import android.content.Context
 import androidx.navigation.NavController
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.feature.syncedtabs.view.SyncedTabsView
 import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.R
@@ -40,7 +41,11 @@ fun SyncedTabsView.ErrorType.toSyncedTabsListItem(context: Context, navControlle
                 errorButton = SyncedTabsListItem.ErrorButton(
                     buttonText = context.getString(R.string.synced_tabs_sign_in_button),
                 ) {
-                    navController.navigate(NavGraphDirections.actionGlobalTurnOnSync())
+                    navController.navigate(
+                        NavGraphDirections.actionGlobalTurnOnSync(
+                            entrypoint = FxAEntrypoint.SyncedTabsMenu,
+                        ),
+                    )
                 },
             )
     }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -780,13 +780,20 @@
         <action
             android:id="@+id/action_turnOnSyncFragment_to_pairFragment"
             app:destination="@id/pairFragment" />
+        <argument
+            android:name="entrypoint"
+            app:argType="mozilla.components.concept.sync.FxAEntrypoint" />
     </fragment>
 
     <fragment
         android:id="@+id/pairFragment"
         android:name="org.mozilla.fenix.settings.PairFragment"
         android:label="@string/preferences_sync_2"
-        tools:layout="@layout/fragment_pair" />
+        tools:layout="@layout/fragment_pair" >
+        <argument
+            android:name="entrypoint"
+            app:argType="mozilla.components.concept.sync.FxAEntrypoint" />
+    </fragment>
 
     <fragment
         android:id="@+id/aboutFragment"
@@ -960,6 +967,9 @@
         <action
             android:id="@+id/action_accountProblemFragment_to_signOutFragment"
             app:destination="@id/signOutFragment" />
+        <argument
+            android:name="entrypoint"
+            app:argType="mozilla.components.concept.sync.FxAEntrypoint" />
     </fragment>
     <dialog
         android:id="@+id/signOutFragment"

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
@@ -34,6 +34,7 @@ import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.prompt.ShareData
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SessionUseCases
@@ -785,7 +786,9 @@ class DefaultBrowserToolbarMenuControllerTest {
     @Test
     fun `GIVEN account exists and the user is not signed in WHEN sign in to sync menu item is pressed THEN navigate to account problem fragment`() = runTest {
         val item = ToolbarMenu.Item.SyncAccount(AccountState.NEEDS_REAUTHENTICATION)
-        val accountProblemDirections = BrowserFragmentDirections.actionGlobalAccountProblemFragment()
+        val accountProblemDirections = BrowserFragmentDirections.actionGlobalAccountProblemFragment(
+            entrypoint = FxAEntrypoint.BrowserToolbar,
+        )
         val controller = createController(scope = this, store = browserStore)
 
         controller.handleToolbarItemInteraction(item)
@@ -796,7 +799,9 @@ class DefaultBrowserToolbarMenuControllerTest {
     @Test
     fun `GIVEN account doesn't exist WHEN sign in to sync menu item is pressed THEN navigate to sign in`() = runTest {
         val item = ToolbarMenu.Item.SyncAccount(AccountState.NO_ACCOUNT)
-        val turnOnSyncDirections = BrowserFragmentDirections.actionGlobalTurnOnSync()
+        val turnOnSyncDirections = BrowserFragmentDirections.actionGlobalTurnOnSync(
+            entrypoint = FxAEntrypoint.BrowserToolbar,
+        )
         val controller = createController(scope = this, store = browserStore)
 
         controller.handleToolbarItemInteraction(item)

--- a/app/src/test/java/org/mozilla/fenix/home/HomeMenuBuilderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/HomeMenuBuilderTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.menu.view.MenuButton
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertNotNull
@@ -116,7 +117,9 @@ class HomeMenuBuilderTest {
         verify {
             navController.nav(
                 R.id.homeFragment,
-                HomeFragmentDirections.actionGlobalAccountProblemFragment(),
+                HomeFragmentDirections.actionGlobalAccountProblemFragment(
+                    entrypoint = FxAEntrypoint.HomeMenu,
+                ),
             )
         }
 
@@ -125,7 +128,7 @@ class HomeMenuBuilderTest {
         verify {
             navController.nav(
                 R.id.homeFragment,
-                HomeFragmentDirections.actionGlobalTurnOnSync(),
+                HomeFragmentDirections.actionGlobalTurnOnSync(entrypoint = FxAEntrypoint.HomeMenu),
             )
         }
     }
@@ -208,7 +211,9 @@ class HomeMenuBuilderTest {
         verify {
             navController.nav(
                 R.id.homeFragment,
-                HomeFragmentDirections.actionGlobalAccountProblemFragment(),
+                HomeFragmentDirections.actionGlobalAccountProblemFragment(
+                    entrypoint = FxAEntrypoint.HomeMenu,
+                ),
             )
         }
     }

--- a/app/src/test/java/org/mozilla/fenix/home/intent/HomeDeepLinkIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/HomeDeepLinkIntentProcessorTest.kt
@@ -18,6 +18,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.sync.FxAEntrypoint
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -121,7 +122,9 @@ class HomeDeepLinkIntentProcessorTest {
         assertTrue(processorHome.process(testIntent("turn_on_sync"), navController, out))
 
         verify { activity wasNot Called }
-        verify { navController.navigate(NavGraphDirections.actionGlobalTurnOnSync()) }
+        verify { navController.navigate(NavGraphDirections.actionGlobalTurnOnSync(
+            entrypoint = FxAEntrypoint.DeepLink,
+        )) }
         verify { out wasNot Called }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingManualSignInViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingManualSignInViewHolderTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.After
@@ -60,7 +61,9 @@ class OnboardingManualSignInViewHolderTest {
         OnboardingManualSignInViewHolder(binding.root)
         binding.fxaSignInButton.performClick()
 
-        verify { navController.navigate(HomeFragmentDirections.actionGlobalTurnOnSync()) }
+        verify { navController.navigate(HomeFragmentDirections.actionGlobalTurnOnSync(
+            entrypoint = FxAEntrypoint.OnboardingManualSignIn
+        )) }
         // Check if the event was recorded
         Assert.assertNotNull(Onboarding.fxaManualSignin.testGetValue())
         assertEquals(1, Onboarding.fxaManualSignin.testGetValue()!!.size)

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SyncPreferenceViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SyncPreferenceViewTest.kt
@@ -20,6 +20,7 @@ import io.mockk.slot
 import io.mockk.unmockkConstructor
 import io.mockk.verify
 import mozilla.components.concept.sync.AccountObserver
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.manager.SyncEnginesStorage
@@ -98,7 +99,7 @@ class SyncPreferenceViewTest {
         assertFalse(preferenceChangeListener.captured.onPreferenceChange(syncPreference, any()))
         verify {
             navController.navigate(
-                SavedLoginsAuthFragmentDirections.actionGlobalAccountProblemFragment(),
+                SavedLoginsAuthFragmentDirections.actionGlobalAccountProblemFragment(entrypoint = FxAEntrypoint.SavedLogins),
             )
         }
     }
@@ -115,7 +116,9 @@ class SyncPreferenceViewTest {
         assertFalse(preferenceChangeListener.captured.onPreferenceChange(syncPreference, any()))
         verify {
             navController.navigate(
-                SavedLoginsAuthFragmentDirections.actionGlobalAccountProblemFragment(),
+                SavedLoginsAuthFragmentDirections.actionGlobalAccountProblemFragment(
+                    entrypoint = FxAEntrypoint.SavedLogins,
+                ),
             )
         }
     }
@@ -132,7 +135,9 @@ class SyncPreferenceViewTest {
         assertFalse(preferenceChangeListener.captured.onPreferenceChange(syncPreference, any()))
         verify {
             navController.navigate(
-                SavedLoginsAuthFragmentDirections.actionSavedLoginsAuthFragmentToTurnOnSyncFragment(),
+                SavedLoginsAuthFragmentDirections.actionSavedLoginsAuthFragmentToTurnOnSyncFragment(
+                    entrypoint = FxAEntrypoint.SavedLogins,
+                ),
             )
         }
     }
@@ -184,12 +189,16 @@ class SyncPreferenceViewTest {
         loggedInTitle = loggedInTitle,
         onSyncSignInClicked = {
             val directions =
-                SavedLoginsAuthFragmentDirections.actionSavedLoginsAuthFragmentToTurnOnSyncFragment()
+                SavedLoginsAuthFragmentDirections.actionSavedLoginsAuthFragmentToTurnOnSyncFragment(
+                    entrypoint = FxAEntrypoint.SavedLogins,
+                )
             navController.navigate(directions)
         },
         onReconnectClicked = {
             val directions =
-                SavedLoginsAuthFragmentDirections.actionGlobalAccountProblemFragment()
+                SavedLoginsAuthFragmentDirections.actionGlobalAccountProblemFragment(
+                    entrypoint = FxAEntrypoint.SavedLogins,
+                )
             navController.navigate(directions)
         },
     )

--- a/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.DeviceType
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.concept.sync.TabData
 import mozilla.components.feature.accounts.push.SendTabUseCases
 import mozilla.components.feature.session.SessionUseCases
@@ -78,7 +79,7 @@ class ShareControllerTest {
     private val testCoroutineScope = coroutinesTestRule.scope
     private val controller = DefaultShareController(
         context, shareSubject, shareData, sendTabUseCases, saveToPdfUseCase, snackbar, navController,
-        recentAppStorage, testCoroutineScope, testDispatcher, dismiss,
+        recentAppStorage, testCoroutineScope, testDispatcher, FxAEntrypoint.ShareMenu, dismiss
     )
 
     @Test
@@ -100,7 +101,8 @@ class ShareControllerTest {
         val activityContext: Context = mockk<Activity>()
         val testController = DefaultShareController(
             activityContext, shareSubject, shareData, mockk(), mockk(),
-            mockk(), mockk(), recentAppStorage, testCoroutineScope, testDispatcher, dismiss,
+            mockk(), mockk(), recentAppStorage, testCoroutineScope, testDispatcher,
+            FxAEntrypoint.ShareMenu, dismiss
         )
         every { activityContext.startActivity(capture(shareIntent)) } just Runs
         every { recentAppStorage.updateRecentApp(appShareOption.activityName) } just Runs
@@ -423,7 +425,9 @@ class ShareControllerTest {
         verifyOrder {
             navController.nav(
                 R.id.shareFragment,
-                ShareFragmentDirections.actionGlobalTurnOnSync(),
+                ShareFragmentDirections.actionGlobalTurnOnSync(
+                    entrypoint = FxAEntrypoint.ShareMenu,
+                ),
             )
             dismiss(ShareController.Result.DISMISSED)
         }
@@ -436,7 +440,9 @@ class ShareControllerTest {
         verifyOrder {
             navController.nav(
                 R.id.shareFragment,
-                ShareFragmentDirections.actionGlobalAccountProblemFragment(),
+                ShareFragmentDirections.actionGlobalAccountProblemFragment(
+                    entrypoint = FxAEntrypoint.ShareMenu
+                ),
             )
             dismiss(ShareController.Result.DISMISSED)
         }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/NavigationInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/NavigationInteractorTest.kt
@@ -21,6 +21,7 @@ import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.storage.sync.TabEntry
+import mozilla.components.concept.sync.FxAEntrypoint
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
@@ -104,7 +105,9 @@ class NavigationInteractorTest {
 
         createInteractor().onAccountSettingsClicked()
 
-        verify(exactly = 1) { navController.navigate(TabsTrayFragmentDirections.actionGlobalTurnOnSync()) }
+        verify(exactly = 1) { navController.navigate(TabsTrayFragmentDirections.actionGlobalTurnOnSync(
+            entrypoint = FxAEntrypoint.NavigationInteraction,
+        )) }
     }
 
     @Test


### PR DESCRIPTION
Needs an android components change.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
   **We don't need screenshots, the entrypoint is passed in as data and is only meant to be reflected in telemetry**
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
No QA needed. The change does not change any user-facing features.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
