### PR TITLE
For #26087 fix disabled tabMediaControlButtonTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -772,7 +772,6 @@ class SmokeTest {
     }
 
     @Test
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
     fun tabMediaControlButtonTest() {
         val audioTestPage = TestAssetHelper.getAudioPageAsset(mockWebServer)
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -32,7 +32,6 @@ import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import androidx.test.uiautomator.Until.findObject
 import com.google.android.material.bottomsheet.BottomSheetBehavior
-import junit.framework.AssertionFailedError
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.hamcrest.CoreMatchers.allOf
@@ -149,75 +148,14 @@ class TabDrawerRobot {
         snackBarButton.click()
     }
 
-    fun verifyTabMediaControlButtonState(action: String) {
-        try {
-            mDevice.findObject(
-                UiSelector().resourceId("$packageName:id/tab_tray_empty_view"),
-            ).waitUntilGone(waitingTime)
-
-            mDevice.findObject(
-                UiSelector().resourceId("$packageName:id/tab_tray_grid_item"),
-            ).waitForExists(waitingTime)
-
-            mDevice.findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/play_pause_button")
-                    .descriptionContains(action),
-            ).waitForExists(waitingTime)
-
-            assertTrue(
-                mDevice.findObject(UiSelector().descriptionContains(action))
-                    .waitForExists(waitingTime),
-            )
-        } catch (e: AssertionFailedError) {
-            // In some cases the tab media button isn't updated after performing an action on it
-            println("Failed to update the state of the tab media button")
-
-            // Let's dismiss the tabs tray and try again
-            mDevice.pressBack()
-            mDevice.findObject(
-                UiSelector()
-                    .resourceId("$packageName:id/toolbar"),
-            ).waitForExists(waitingTime)
-
-            browserScreen {
-            }.openTabDrawer {
-                // Click again the tab media button
-                tabMediaControlButton().click()
-
-                mDevice.findObject(
-                    UiSelector().resourceId("$packageName:id/tab_tray_empty_view"),
-                ).waitUntilGone(waitingTime)
-
-                mDevice.findObject(
-                    UiSelector().resourceId("$packageName:id/tab_tray_grid_item"),
-                ).waitForExists(waitingTime)
-
-                mDevice.findObject(
-                    UiSelector()
-                        .resourceId("$packageName:id/play_pause_button")
-                        .descriptionContains(action),
-                ).waitForExists(waitingTime)
-
-                assertTrue(
-                    mDevice.findObject(UiSelector().descriptionContains(action))
-                        .waitForExists(waitingTime),
-                )
-            }
-        }
-    }
+    fun verifyTabMediaControlButtonState(action: String) =
+        assertTrue(tabMediaControlButton(action).waitForExists(waitingTime))
 
     fun clickTabMediaControlButton(action: String) {
-        mDevice.waitNotNull(
-            Until.findObjects(
-                By
-                    .res("$packageName:id/play_pause_button")
-                    .descContains(action),
-            ),
-            waitingTime,
-        )
-
-        tabMediaControlButton().click()
+        tabMediaControlButton(action).also {
+            it.waitForExists(waitingTime)
+            it.click()
+        }
     }
 
     fun clickSelectTabsOption() {
@@ -449,8 +387,8 @@ fun tabDrawer(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
     return TabDrawerRobot.Transition()
 }
 
-private fun tabMediaControlButton() =
-    mDevice.findObject(UiSelector().resourceId("$packageName:id/play_pause_button"))
+private fun tabMediaControlButton(action: String) =
+    mDevice.findObject(UiSelector().descriptionContains(action))
 
 private fun closeTabButton() =
     mDevice.findObject(UiSelector().descriptionContains("Close tab"))


### PR DESCRIPTION
For #26087 fix disabled `tabMediaControlButtonTest` UI test ✅ successfully passed 75x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #26087