### PR TITLE
For #28165 fix showDefaultHomeScreen screenshot UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -194,7 +194,10 @@ class HomeScreenRobot {
 
     // First Run elements
     fun verifyWelcomeHeader() = assertItemContainingTextExists(welcomeHeader)
-    fun verifyAccountsSignInButton() = assertItemWithResIdExists(signInButton)
+    fun verifyAccountsSignInButton() {
+        scrollToElementByText(getStringResource(R.string.onboarding_account_sign_in_header))
+        assertItemWithResIdExists(signInButton)
+    }
     fun verifyStartBrowsingButton() {
         scrollToElementByText(getStringResource(R.string.onboarding_finish))
         assertItemWithResIdExists(startBrowsingButton)


### PR DESCRIPTION
For #28165 fix `showDefaultHomeScreen` screenshot UI test ✅ successfully passed 75x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #28165