### PR TITLE
Issue #27312: Fallback measure for ETP UI tests and re-enabling them

### DIFF
--- a/app/src/androidTest/assets/pages/trackingPage.html
+++ b/app/src/androidTest/assets/pages/trackingPage.html
@@ -13,31 +13,31 @@
     <h3>Level 1 (Basic) List</h3>
     <p>social-track-digest256:</p>
     <img
-            src="https://social-track-digest256.dummytracker.org/test_not_blocked.png"
-            onerror="this.onerror=null;this.src='https://not-a-tracker.dummytracker.org/test_blocked.png'">
+            src="https://social-track-digest256.dummytracker.org/test_not_blocked.png" alt="social not blocked"
+            onerror="this.onerror=null;this.src='https://not-a-tracker.dummytracker.org/test_blocked.png';this.alt='social blocked'">
     <br/>
     <p>ads-track-digest256:</p>
     <img
             src="https://ads-track-digest256.dummytracker.org/test_not_blocked.png"
-            onerror="this.onerror=null;this.src='https://not-a-tracker.dummytracker.org/test_blocked.png'">
+            onerror="this.onerror=null;this.src='https://not-a-tracker.dummytracker.org/test_blocked.png';this.alt='ads blocked'">
     <br/>
     <p>analytics-track-digest256:</p>
     <img
             src="https://analytics-track-digest256.dummytracker.org/test_not_blocked.png"
-            onerror="this.onerror=null;this.src='https://not-a-tracker.dummytracker.org/test_blocked.png'">
+            onerror="this.onerror=null;this.src='https://not-a-tracker.dummytracker.org/test_blocked.png';this.alt='analytics blocked'">
     <br/>
     <p>Fingerprinting:
     <pre id="result">test not run</pre>
     <script src="https://base-fingerprinting-track-digest256.dummytracker.org/tracker.js"
-            onerror="this.onerror=null;var result=document.getElementById('result');result.innerHTML='blocked';"
-            onload="this.onload=null;var result=document.getElementById('result');result.innerHTML='NOT blocked';"
+            onerror="this.onerror=null;var result=document.getElementById('result');result.innerHTML='Fingerprinting blocked';"
+            onload="this.onload=null;var result=document.getElementById('result');result.innerHTML='Fingerprinting NOT blocked';"
     ></script>
     </p>
     <br/>
     <p>Cryptomining:
       <img
-              src="https://base-cryptomining-track-digest256.dummytracker.org/test_not_blocked.png" alt="not blocked"
-              onerror="this.onerror=null;this.src='https://not-a-tracker.dummytracker.org/test_blocked.png';this.alt='blocked'">
+              src="https://base-cryptomining-track-digest256.dummytracker.org/test_not_blocked.png" alt="Cryptomining not blocked"
+              onerror="this.onerror=null;this.src='https://not-a-tracker.dummytracker.org/test_blocked.png';this.alt='Cryptomining blocked'">
     </p>
 
     <p><b>Cookie blocking</b>

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/EnhancedTrackingProtectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/EnhancedTrackingProtectionTest.kt
@@ -8,7 +8,6 @@ import androidx.core.net.toUri
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -165,7 +164,6 @@ class EnhancedTrackingProtectionTest {
         }
     }
 
-    @Ignore("Permanent failure: https://github.com/mozilla-mobile/fenix/issues/27312")
     @Test
     fun testStrictVisitSheetDetails() {
         appContext.settings().setStrictETP()
@@ -182,7 +180,11 @@ class EnhancedTrackingProtectionTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(trackingProtectionTest.url) {
-            verifyTrackingProtectionWebContent("blocked")
+            verifyTrackingProtectionWebContent("social blocked")
+            verifyTrackingProtectionWebContent("ads blocked")
+            verifyTrackingProtectionWebContent("analytics blocked")
+            verifyTrackingProtectionWebContent("Fingerprinting blocked")
+            verifyTrackingProtectionWebContent("Cryptomining blocked")
         }
         enhancedTrackingProtection {
         }.openEnhancedTrackingProtectionSheet {
@@ -197,7 +199,6 @@ class EnhancedTrackingProtectionTest {
         }
     }
 
-    @Ignore("Permanent failure: https://github.com/mozilla-mobile/fenix/issues/27312")
     @SmokeTest
     @Test
     fun customTrackingProtectionSettingsTest() {
@@ -217,7 +218,13 @@ class EnhancedTrackingProtectionTest {
             // browsing a basic page to allow GV to load on a fresh run
         }.enterURLAndEnterToBrowser(genericWebPage.url) {
         }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(trackingPage.url) {}
+        }.enterURLAndEnterToBrowser(trackingPage.url) {
+            verifyTrackingProtectionWebContent("social blocked")
+            verifyTrackingProtectionWebContent("ads blocked")
+            verifyTrackingProtectionWebContent("analytics blocked")
+            verifyTrackingProtectionWebContent("Fingerprinting blocked")
+            verifyTrackingProtectionWebContent("Cryptomining blocked")
+        }
 
         enhancedTrackingProtection {
         }.openEnhancedTrackingProtectionSheet {


### PR DESCRIPTION
Re-ran the tests 400 times on Firebase and they are looking perfectly stable for now. I've also added some retries in case TP is not yet working, to reload the test page up to 3 times.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #27312