### PR TITLE
Closes #28205: fix ripple position over unified search icon

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelector.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelector.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.ViewGroup
 import android.widget.RelativeLayout
 import org.mozilla.fenix.databinding.SearchSelectorBinding
 
@@ -22,21 +21,9 @@ internal class SearchSelector @JvmOverloads constructor(
 ) : RelativeLayout(context, attrs, defStyle) {
 
     private val binding = SearchSelectorBinding.inflate(LayoutInflater.from(context), this)
-    private var marginTop: Int = 0
-
-    override fun setLayoutParams(params: ViewGroup.LayoutParams?) {
-        if (params is MarginLayoutParams) {
-            params.topMargin = marginTop
-        }
-        super.setLayoutParams(params)
-    }
 
     fun setIcon(icon: Drawable?, contentDescription: String?) {
         binding.icon.setImageDrawable(icon)
         binding.icon.contentDescription = contentDescription
-    }
-
-    fun setTopMargin(margin: Int) {
-        marginTop = margin
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelectorToolbarAction.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelectorToolbarAction.kt
@@ -55,7 +55,9 @@ class SearchSelectorToolbarAction(
                 menu.menuController.show(anchor = it, orientation = orientation, forceOrientation = true)
             }
 
-            setTopMargin(resources.getDimensionPixelSize(R.dimen.search_engine_engine_icon_top_margin))
+            val topPadding = resources.getDimensionPixelSize(R.dimen.search_engine_engine_icon_top_margin)
+            setPadding(0, topPadding, 0, 0)
+
             setBackgroundResource(
                 context.theme.resolveAttribute(android.R.attr.selectableItemBackgroundBorderless),
             )


### PR DESCRIPTION
Fixing a bug introduced by me [here](https://github.com/mozilla-mobile/fenix/pull/27647).
The margin was shifting the ripple. Implemented in line with [AC padding handling](https://searchfox.org/mozilla-mobile/source/firefox-android/android-components/components/concept/toolbar/src/main/java/mozilla/components/concept/toolbar/Toolbar.kt#301) for action buttons.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #28205