### PR TITLE
For #28182 fix for verifySearchEnginesWithRTLLocale UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -390,7 +390,6 @@ class SettingsSearchTest {
 
     // Expected for app language set to Arabic
     @Test
-    @Ignore("Failing after changing SearchDialog homescreen interaction. See: https://github.com/mozilla-mobile/fenix/issues/28182")
     fun verifySearchEnginesWithRTLLocale() {
         homeScreen {
         }.openThreeDotMenu {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -284,7 +284,7 @@ class SearchRobot {
     fun verifySearchEngineShortcuts(rule: ComposeTestRule, vararg searchEngines: String) {
         mDevice.findObject(
             UiSelector().resourceId("$packageName:id/awesome_bar"),
-        ).swipeUp(1)
+        ).swipeUp(3)
 
         for (searchEngine in searchEngines) {
             rule.waitForIdle()


### PR DESCRIPTION
For #28182 fix for `verifySearchEnginesWithRTLLocale` UI test ✅ successfully passed 75x on Firebase.

Summary:
When it tried to swipe up using only one step, it actually clicked a random search engine shortcut.
Changed it to 3 steps and works properly.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #28182