### PR TITLE
For #28155 - Show search terms in address bar for both edit and display modes

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -42,6 +42,7 @@ abstract class ToolbarIntegration(
         toolbar,
         store,
         sessionId,
+        context.settings().showUnifiedSearchFeature,
         ToolbarFeature.UrlRenderConfiguration(
             context.components.publicSuffixList,
             ThemeManager.resolveAttribute(R.attr.textPrimary, context),

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/BrowserToolbarViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/BrowserToolbarViewTest.kt
@@ -20,6 +20,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.utils.Settings
 import mozilla.components.browser.toolbar.behavior.ToolbarPosition as MozacToolbarPosition
@@ -41,6 +42,7 @@ class BrowserToolbarViewTest {
         every { testContext.components.useCases } returns mockk(relaxed = true)
         every { testContext.components.core } returns mockk(relaxed = true)
         every { testContext.components.publicSuffixList } returns PublicSuffixList(testContext)
+        every { testContext.settings().showUnifiedSearchFeature } returns false
 
         toolbarView = BrowserToolbarView(
             context = testContext,

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "110.0.20221215190237"
+    const val VERSION = "110.0.20221216143118"
 }


### PR DESCRIPTION
When unified search is enabled, show the search terms when the address bar is in display mode.

https://user-images.githubusercontent.com/35462038/208100060-35b4992c-2a85-4380-9fbc-2e2d31a6b29b.mp4

Adresses breaking changes from https://github.com/mozilla-mobile/firefox-android/pull/294

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #28155