### PR TITLE
Bug 1804383 - Save as PDF text is missing in Private Mode

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -31,6 +31,7 @@ import org.mozilla.fenix.databinding.FragmentShareBinding
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.theme.FirefoxTheme
+import org.mozilla.fenix.theme.Theme
 
 class ShareFragment : AppCompatDialogFragment() {
 
@@ -122,7 +123,7 @@ class ShareFragment : AppCompatDialogFragment() {
                 isVisible = true
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                 setContent {
-                    FirefoxTheme {
+                    FirefoxTheme(theme = Theme.getTheme(allowPrivateTheme = false)) {
                         SaveToPDFItem {
                             shareInteractor.onSaveToPDF(tabId = args.sessionId)
                         }


### PR DESCRIPTION
The share sheet behave different our colours themes, in dark mode and private mode we use dark colour layer, but the share sheet keeps a white background for private mode, this is the same issue as https://github.com/mozilla-mobile/fenix/pull/26376, as `SaveToPDFItem` is following our colours themes is using a white colour in private mode, as it's an exception to our scheme we need to remove private theme to be applied.


# Private mode
![image](https://user-images.githubusercontent.com/773158/208244856-ba9f61fc-ea96-49b4-958d-83d8d566fdbc.png)


# Normal mode
![image](https://user-images.githubusercontent.com/773158/208244725-42fbb086-fcff-40e4-bcdd-92c11cda4c15.png)

# Dark mode
![image](https://user-images.githubusercontent.com/773158/208244593-0812f66f-ae2b-40ce-aec9-f745d7c8afe9.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
