### PR TITLE
Bug 1800611 - Bump relbot to 5.0.2

### DIFF
--- a/.github/workflows/fenix-update-ac.yml
+++ b/.github/workflows/fenix-update-ac.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Update Android-Components"
-        uses: mozilla-mobile/relbot@1.0.0
+        uses: mozilla-mobile/relbot@5.0.2
         if: github.repository == 'mozilla-mobile/fenix'
         with:
           project: fenix


### PR DESCRIPTION
https://github.com/mozilla-mobile/fenix/actions/runs/3727141208/jobs/6321034383

```
This is relbot working on https://github.com/mozilla-mobile as sebastian@mozilla.com / MickeyMoz
2022-12-18 23:48:08.50[9](https://github.com/mozilla-mobile/fenix/actions/runs/3727141208/jobs/6321034383#step:3:10)306 Current A-C version in Repository(full_name="mozilla-mobile/fenix") is 1[10](https://github.com/mozilla-mobile/fenix/actions/runs/3727141208/jobs/6321034383#step:3:11).0.20221217143322
2022-12-18 23:48:08.766630 We should upgrade Repository(full_name="mozilla-mobile/fenix") to Android-Components 110.0.20221218143302
2022-12-18 23:48:08.887141 The PR branch relbot/AC-Nightly-[11](https://github.com/mozilla-mobile/fenix/actions/runs/3727141208/jobs/6321034383#step:3:12)0.0.2022[12](https://github.com/mozilla-mobile/fenix/actions/runs/3727141208/jobs/6321034383#step:3:13)18143302 already exists. Exiting.
2022-12-18 23:48:09.169077 Looking at fenix 108
2022-12-18 23:48:09.321228 Looking at fenix 108 on releases_v108.0.0
2022-12-18 23:48:09.455898 Current A-C version in fenix is 108.0.8
2022-12-18 23:48:09.755596 Latest A-C version available is 108.0.8
2022-12-18 23:48:09.755617 No need to upgrade; fenix 108 is on A-C 108.0.8
2022-12-18 23:48:09.755642 Looking at fenix 109
2022-12-[18](https://github.com/mozilla-mobile/fenix/actions/runs/3727141208/jobs/6321034383#step:3:19) 23:48:09.921048 Looking at fenix 109 on releases_v109.0.0
2022-12-18 23:48:10.053607 Failed to update A-C in Fenix 109: Invalid AC version format 109.0b1
```
Our existing Fenix relbot is still stuck in 1.0.0. In 5.0.2, we have offloaded the parsing of the beta version to [mozilla-version](https://github.com/mozilla-releng/mozilla-version). 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
