### PR TITLE
Bug 1796319 - Select existing addon settings tab if already opened

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
@@ -243,7 +243,12 @@ class InstalledAddonDetailsFragment : Fragment() {
                     val shouldCreatePrivateSession =
                         (activity as HomeActivity).browsingModeManager.mode.isPrivate
 
-                    components.useCases.tabsUseCases.addTab(settingUrl, private = shouldCreatePrivateSession)
+                    // If the addon settings page is already open in a tab, select that one
+                    components.useCases.tabsUseCases.selectOrAddTab(
+                        url = settingUrl,
+                        private = shouldCreatePrivateSession,
+                        ignoreFragment = true,
+                    )
 
                     InstalledAddonDetailsFragmentDirections.actionGlobalBrowser(null)
                 } else {


### PR DESCRIPTION
## How
• Use `SelectOrAddTabUsecase` and ignore the fragment identifier of the url.
• [Here's the A-C patch updating the usecase ](https://github.com/mozilla-mobile/firefox-android/pull/343) along with unit tests.

## Video
https://user-images.githubusercontent.com/38040960/208643225-bc8b76e8-c4fe-427a-bfee-1a40ae4df848.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
