### PR TITLE
Bug 1807270 - re-enable collections UI tests disabled by the tabs tray migration to compose

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
@@ -36,16 +36,18 @@ class CollectionTest {
     private val collectionName = "First Collection"
 
     @get:Rule
-    val composeTestRule = AndroidComposeTestRule(
-        // disabling these features to have better visibility of Collections,
-        // and to avoid multiple matches on tab items
-        HomeActivityIntentTestRule(
-            isPocketEnabled = false,
-            isJumpBackInCFREnabled = false,
-            isRecentTabsFeatureEnabled = false,
-            isRecentlyVisitedFeatureEnabled = false,
-        ),
-    ) { it.activity }
+    val composeTestRule =
+        AndroidComposeTestRule(
+            HomeActivityIntentTestRule(
+                isHomeOnboardingDialogEnabled = false,
+                isJumpBackInCFREnabled = false,
+                isRecentTabsFeatureEnabled = false,
+                isRecentlyVisitedFeatureEnabled = false,
+                isPocketEnabled = false,
+                isWallpaperOnboardingEnabled = false,
+                isTCPCFREnabled = false,
+            ),
+        ) { it.activity }
 
     @Before
     fun setUp() {
@@ -63,7 +65,6 @@ class CollectionTest {
 
     @SmokeTest
     @Test
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
     fun createFirstCollectionTest() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
         val secondWebPage = getGenericAsset(mockWebServer, 2)
@@ -76,7 +77,6 @@ class CollectionTest {
         }.submitQuery(secondWebPage.url.toString()) {
             mDevice.waitForIdle()
         }.goToHomescreen {
-            swipeToBottom()
         }.clickSaveTabsToCollectionButton {
             longClickTab(firstWebPage.title)
             selectTab(secondWebPage.title, numOfTabs = 2)
@@ -96,7 +96,6 @@ class CollectionTest {
 
     @SmokeTest
     @Test
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
     fun verifyExpandedCollectionItemsTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
         val webPageUrl = webPage.url.host.toString()
@@ -146,7 +145,6 @@ class CollectionTest {
 
     @SmokeTest
     @Test
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
     fun openAllTabsInCollectionTest() {
         val firstTestPage = getGenericAsset(mockWebServer, 1)
         val secondTestPage = getGenericAsset(mockWebServer, 2)
@@ -179,7 +177,6 @@ class CollectionTest {
 
     @SmokeTest
     @Test
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
     fun shareCollectionTest() {
         val firstWebsite = getGenericAsset(mockWebServer, 1)
         val secondWebsite = getGenericAsset(mockWebServer, 2)
@@ -204,11 +201,10 @@ class CollectionTest {
         }
     }
 
-    @SmokeTest
-    @Test
     // Test running on beta/release builds in CI:
     // caution when making changes to it, so they don't block the builds
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
+    @SmokeTest
+    @Test
     fun deleteCollectionTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
 
@@ -231,9 +227,8 @@ class CollectionTest {
         }
     }
 
-    @Test
     // open a webpage, and add currently opened tab to existing collection
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
+    @Test
     fun mainMenuSaveToExistingCollection() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
         val secondWebPage = getGenericAsset(mockWebServer, 2)
@@ -260,7 +255,6 @@ class CollectionTest {
     }
 
     @Test
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
     fun verifyAddTabButtonOfCollectionMenu() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
         val secondWebPage = getGenericAsset(mockWebServer, 2)
@@ -287,7 +281,6 @@ class CollectionTest {
     }
 
     @Test
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
     fun renameCollectionTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
 
@@ -308,7 +301,6 @@ class CollectionTest {
     }
 
     @Test
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
     fun createSecondCollectionTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
 
@@ -331,7 +323,6 @@ class CollectionTest {
     }
 
     @Test
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
     fun removeTabFromCollectionTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
 
@@ -354,7 +345,6 @@ class CollectionTest {
     }
 
     @Test
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
     fun swipeLeftToRemoveTabFromCollectionTest() {
         val testPage = getGenericAsset(mockWebServer, 1)
 
@@ -381,7 +371,6 @@ class CollectionTest {
     }
 
     @Test
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
     fun swipeRightToRemoveTabFromCollectionTest() {
         val testPage = getGenericAsset(mockWebServer, 1)
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
@@ -23,6 +23,7 @@ import androidx.test.uiautomator.Until
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
@@ -57,7 +58,11 @@ class CollectionRobot {
     // names a collection saved from tab drawer
     fun typeCollectionNameAndSave(collectionName: String) {
         collectionNameTextField().text = collectionName
-        mDevice.findObject(UiSelector().textContains("OK")).click()
+        addCollectionButtonPanel.waitForExists(waitingTime)
+        addCollectionOkButton.also {
+            it.waitForExists(waitingTime)
+            it.click()
+        }
     }
 
     fun verifyTabsSelectedCounterText(numOfTabs: Int) {
@@ -289,3 +294,8 @@ private fun backButton() =
     mDevice.findObject(
         UiSelector().resourceId("$packageName:id/back_button"),
     )
+private val addCollectionButtonPanel =
+    itemWithResId("$packageName:id/buttonPanel")
+
+private val addCollectionOkButton =
+    itemWithResId("android:id/button1")

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -688,6 +688,7 @@ class HomeScreenRobot {
         }
 
         fun clickSaveTabsToCollectionButton(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
+            scrollToElementByText(getStringResource(R.string.no_collections_description2))
             saveTabsToCollectionButton().click()
 
             TabDrawerRobot().interact()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -14,9 +14,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.GeneralLocation
-import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.action.ViewActions.longClick
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.RootMatchers
@@ -114,7 +112,7 @@ class TabDrawerRobot {
         var retries = 0 // number of retries before failing, will stop at 2
         while (!tabItem(title).waitUntilGone(waitingTimeShort) && retries < 3
         ) {
-            tab(title).perform(ViewActions.swipeRight())
+            tab(title).swipeRight(3)
             retries++
         }
     }
@@ -123,7 +121,7 @@ class TabDrawerRobot {
         var retries = 0 // number of retries before failing, will stop at 2
         while (!tabItem(title).waitUntilGone(waitingTimeShort) && retries < 3
         ) {
-            tab(title).perform(ViewActions.swipeLeft())
+            tab(title).swipeLeft(3)
             retries++
         }
     }
@@ -183,7 +181,10 @@ class TabDrawerRobot {
             waitingTime,
         )
 
-        tab(title).perform(longClick())
+        tab(title).also {
+            it.waitForExists(waitingTime)
+            it.longClick()
+        }
     }
 
     fun createCollection(
@@ -560,12 +561,7 @@ private val tabsList =
 
 // This Espresso tab selector is used for actions that UIAutomator doesn't handle very well: swipe and long-tap
 private fun tab(title: String) =
-    onView(
-        allOf(
-            withId(R.id.mozac_browser_tabstray_title),
-            withText(title),
-        ),
-    )
+    mDevice.findObject(UiSelector().textContains(title))
 
 // This tab selector is used for actions that involve waiting and asserting the existence of the view
 private fun tabItem(title: String) =


### PR DESCRIPTION
For #26087 re-enable collections UI tests disabled by the tabs tray migration to compose.

The following tests are re-enabled and successfully passed 75x on Firebase:
`createFirstCollectionTest`
`verifyExpandedCollectionItemsTest`
`shareCollectionTest`
`mainMenuSaveToExistingCollection`
`createSecondCollectionTest`
`renameCollectionTest`
`deleteCollectionTest`
`verifyAddTabButtonOfCollectionMenu`
`openAllTabsInCollectionTest`
`removeTabFromCollectionTest`
`swipeLeftToRemoveTabFromCollectionTest`
`swipeRightToRemoveTabFromCollectionTest`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
Fixes #26087