### PR TITLE
For #27035 - Add padding around onboarding buttons and content

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/onboarding/view/Onboarding.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/view/Onboarding.kt
@@ -164,7 +164,7 @@ private fun OnboardingWelcomeBottomContent(
 @Composable
 private fun OnboardingWelcomeContent() {
     Column(
-        modifier = Modifier.padding(horizontal = 16.dp),
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Image(
@@ -195,7 +195,7 @@ private fun OnboardingWelcomeContent() {
 @Composable
 private fun OnboardingSyncSignInContent() {
     Column(
-        modifier = Modifier.padding(horizontal = 16.dp),
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Image(


### PR DESCRIPTION

![Screen Shot 2022-12-21 at 11 43 37 AM](https://user-images.githubusercontent.com/29518411/208965204-fb010fb0-e3fc-4cc7-9a8b-7aa13c893b58.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #27035