### PR TITLE
For #28273 - Configure search with the selected search engine before user searching

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/search/SearchDialogFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchDialogFragmentTest.kt
@@ -8,15 +8,25 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
+import io.mockk.Called
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import io.mockk.verify
+import mozilla.components.browser.state.search.SearchEngine
+import mozilla.components.browser.state.state.SearchState
+import mozilla.components.browser.state.state.searchEngines
+import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
 import org.junit.After
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
+import org.mozilla.fenix.components.Components
+import org.mozilla.fenix.ext.requireComponents
 
 internal class SearchDialogFragmentTest {
     private val navController: NavController = mockk()
@@ -77,6 +87,71 @@ internal class SearchDialogFragmentTest {
         )
 
         assertSame(fragmentADestination, fragment.getPreviousDestination())
+    }
+
+    @Test
+    fun `GIVEN the default search engine is currently selected WHEN checking the need to update the current search engine THEN don't to anything`() {
+        fragment.interactor = mockk()
+        val defaultSearchEngine: SearchEngine = mockk {
+            every { id } returns "default"
+        }
+        val otherSearchEngine: SearchEngine = mockk {
+            every { id } returns "other"
+        }
+        val components: Components = mockk {
+            every { core.store.state.search } returns mockk(relaxed = true) {
+                every { searchEngines } returns listOf(otherSearchEngine, defaultSearchEngine)
+            }
+        }
+        mockkStatic(
+            "org.mozilla.fenix.ext.FragmentKt",
+            "mozilla.components.browser.state.state.SearchStateKt",
+        ) {
+            every { any<Fragment>().requireComponents } returns components
+            every { any<SearchState>().selectedOrDefaultSearchEngine } returns defaultSearchEngine
+
+            fragment.maybeSelectShortcutEngine(defaultSearchEngine.id)
+
+            verify { fragment.interactor wasNot Called }
+        }
+    }
+
+    @Test
+    fun `GIVEN the default search engine is not currently selected WHEN checking the need to update the current search engine THEN update it to the current engine`() {
+        fragment.interactor = mockk {
+            every { onSearchShortcutEngineSelected(any()) } just Runs
+        }
+        val defaultSearchEngine: SearchEngine = mockk {
+            every { id } returns "default"
+        }
+        val otherSearchEngine: SearchEngine = mockk {
+            every { id } returns "other"
+        }
+        val components: Components = mockk {
+            every { core.store.state.search } returns mockk(relaxed = true) {
+                every { searchEngines } returns listOf(otherSearchEngine, defaultSearchEngine)
+            }
+        }
+        mockkStatic(
+            "org.mozilla.fenix.ext.FragmentKt",
+            "mozilla.components.browser.state.state.SearchStateKt",
+        ) {
+            every { any<Fragment>().requireComponents } returns components
+            every { any<SearchState>().selectedOrDefaultSearchEngine } returns defaultSearchEngine
+
+            fragment.maybeSelectShortcutEngine(otherSearchEngine.id)
+
+            verify { fragment.interactor.onSearchShortcutEngineSelected(otherSearchEngine) }
+        }
+    }
+
+    @Test
+    fun `GIVEN the currently selected search engine is unknown WHEN checking the need to update the current search engine THEN don't do anything`() {
+        fragment.interactor = mockk()
+
+        fragment.maybeSelectShortcutEngine(null)
+
+        verify { fragment.interactor wasNot Called }
     }
 }
 


### PR DESCRIPTION


https://user-images.githubusercontent.com/11428869/209098478-c59de00b-4c1f-4bb1-8d28-49f94bad6c1c.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #28273