### PR TITLE
Bug 1807933 - Enable places storage maintenance feature for the Beta variant

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -72,5 +72,5 @@ object FeatureFlags {
      *
      * Feature flag tracking: https://github.com/mozilla-mobile/fenix/issues/27759
      * */
-    val storageMaintenanceFeature = Config.channel.isNightlyOrDebug
+    val storageMaintenanceFeature = Config.channel.isNightlyOrDebug || Config.channel.isBeta
 }


### PR DESCRIPTION
Places storage maintenance flag is enabled for the Beta variant, previously it was enabled only for Nightly variant. This feature registers a periodic storage maintenance worker that runs to prune and maintain places db.

The flag is also tracked via [this Github issue.](https://github.com/mozilla-mobile/fenix/issues/27759)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
