### PR TITLE
Draft/ POC - Improve layouts for smaller screens

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -479,6 +479,7 @@ dependencies {
     implementation FenixDependencies.kotlin_coroutines
     implementation FenixDependencies.kotlin_coroutines_android
     testImplementation FenixDependencies.kotlin_coroutines_test
+    testImplementation FenixDependencies.cashapp_turbine
     implementation FenixDependencies.androidx_appcompat
     implementation FenixDependencies.androidx_constraintlayout
     implementation FenixDependencies.androidx_coordinatorlayout

--- a/app/src/main/java/org/mozilla/fenix/onboarding/HomeOnboardingDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/HomeOnboardingDialogFragment.kt
@@ -13,6 +13,7 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.google.accompanist.insets.ProvideWindowInsets
 import mozilla.components.lib.state.ext.observeAsComposableState
@@ -20,13 +21,17 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.onboarding.view.Onboarding
+import org.mozilla.fenix.onboarding.view.OnboardingScreen
+import org.mozilla.fenix.onboarding.view.OnboardingViewModel
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
  * Dialog displaying a welcome and sync sign in onboarding.
  */
 class HomeOnboardingDialogFragment : DialogFragment() {
+
+    private val viewModel: OnboardingViewModel by activityViewModels()
+
     @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -52,8 +57,8 @@ class HomeOnboardingDialogFragment : DialogFragment() {
                     val account =
                         components.backgroundServices.syncStore.observeAsComposableState { state -> state.account }
 
-                    Onboarding(
-                        isSyncSignIn = account.value != null,
+                    OnboardingScreen(
+                        isUserSignedIn = account.value != null,
                         onDismiss = ::onDismiss,
                         onSignInButtonClick = {
                             findNavController().nav(
@@ -62,6 +67,7 @@ class HomeOnboardingDialogFragment : DialogFragment() {
                             )
                             onDismiss()
                         },
+                        viewModel = viewModel,
                     )
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingViewModel.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingViewModel.kt
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.onboarding.view
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import mozilla.telemetry.glean.private.NoExtras
+import org.mozilla.fenix.GleanMetrics.Onboarding
+import org.mozilla.fenix.R
+
+/**
+ * ViewModel holding the screen state for [OnboardingScreen].
+ */
+class OnboardingViewModel : ViewModel() {
+
+    private val _state = MutableStateFlow<OnboardingScreenState>(OnboardingScreenState.Initial)
+    internal val state: StateFlow<OnboardingScreenState> = _state
+    private val _navigationEvent = MutableSharedFlow<OnboardingNavigationEvent>()
+    internal val navigationEvent: SharedFlow<OnboardingNavigationEvent> = _navigationEvent
+
+    /**
+     * This should be called onLaunch of [OnboardingScreen] to update to the Content State.
+     */
+    fun onLaunch(isUserSignedIn: Boolean) {
+        if (_state.value is OnboardingScreenState.Initial) {
+            _state.value = OnboardingScreenState.Content(
+                onboardingState = OnboardingState.Welcome,
+                isUserSignedIn = isUserSignedIn,
+            )
+        }
+    }
+
+    /**
+     * Click handler for primary button.
+     */
+    fun onPrimaryButtonClick() {
+        viewModelScope.launch {
+            stateIsContent {
+                when (it.onboardingState) {
+                    OnboardingState.Welcome -> {
+                        Onboarding.welcomeGetStartedClicked.record(NoExtras())
+                        if (it.isUserSignedIn) {
+                            _navigationEvent.emit(OnboardingNavigationEvent.DISMISS)
+                        } else {
+                            _state.value = it.copy(onboardingState = OnboardingState.SyncSignIn)
+                        }
+                    }
+                    OnboardingState.SyncSignIn -> {
+                        Onboarding.syncSignInClicked.record(NoExtras())
+                        _navigationEvent.emit(OnboardingNavigationEvent.SIGN_IN)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Click handler for secondary button.
+     */
+    fun onSecondaryButtonClick() {
+        viewModelScope.launch {
+            stateIsContent {
+                when (it.onboardingState) {
+                    OnboardingState.Welcome -> {
+                        // nothing as welcome doesn't have a secondary button
+                    }
+                    OnboardingState.SyncSignIn -> {
+                        Onboarding.syncSkipClicked.record(NoExtras())
+                        _navigationEvent.emit(OnboardingNavigationEvent.DISMISS)
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun stateIsContent(block: suspend (OnboardingScreenState.Content) -> Unit) {
+        if (_state.value is OnboardingScreenState.Content) {
+            block(_state.value as OnboardingScreenState.Content)
+        }
+    }
+}
+
+/**
+ * Enum that represents the onboarding page that is displayed.
+ */
+enum class OnboardingState {
+    Welcome,
+    SyncSignIn,
+}
+
+/**
+ * State of the Onboarding Screen.
+ */
+sealed class OnboardingScreenState {
+    /**
+     * The Initial state of the screen when the content isn't loaded.
+     * Can be used to show a progress bar if required.
+     */
+    object Initial : OnboardingScreenState()
+
+    /**
+     * The Content state of the screen.
+     * @param onboardingState the page that is selected.
+     * @param isUserSignedIn boolean that signifies if the user has signed in.
+     * pageUiState is a derived property that contains the page data based on [onboardingState].
+     */
+    data class Content(
+        val onboardingState: OnboardingState,
+        val isUserSignedIn: Boolean,
+    ) : OnboardingScreenState() {
+        val pageUiState: OnboardingPageUiState = when (onboardingState) {
+            OnboardingState.Welcome -> OnboardingPageUiState(
+                image = R.drawable.ic_onboarding_welcome,
+                title = R.string.onboarding_home_welcome_title_2,
+                description = R.string.onboarding_home_welcome_description,
+                primaryButtonText = R.string.onboarding_home_get_started_button,
+                recordImpressionEvent = { Onboarding.welcomeCardImpression.record(NoExtras()) },
+            )
+            OnboardingState.SyncSignIn -> OnboardingPageUiState(
+                image = R.drawable.ic_onboarding_sync,
+                title = R.string.onboarding_home_sync_title_3,
+                description = R.string.onboarding_home_sync_description,
+                primaryButtonText = R.string.onboarding_home_sign_in_button,
+                secondaryButtonText = R.string.onboarding_home_skip_button,
+                recordImpressionEvent = { Onboarding.syncCardImpression.record(NoExtras()) },
+            )
+        }
+    }
+}
+
+/**
+ * Onboarding Page data state.
+ */
+data class OnboardingPageUiState(
+    @DrawableRes val image: Int,
+    @StringRes val title: Int,
+    @StringRes val description: Int,
+    @StringRes val primaryButtonText: Int,
+    @StringRes val secondaryButtonText: Int? = null,
+    val recordImpressionEvent: () -> Unit,
+)
+
+/**
+ * Navigation events based on user actions.
+ */
+enum class OnboardingNavigationEvent {
+    DISMISS,
+    SIGN_IN,
+}

--- a/app/src/main/java/org/mozilla/fenix/theme/FirefoxDimens.kt
+++ b/app/src/main/java/org/mozilla/fenix/theme/FirefoxDimens.kt
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("ConstructorParameterNaming")
+
+package org.mozilla.fenix.theme
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * A grid system. Smaller components can align to a 'sub' grid [grid_0_25] or [grid_0_5].
+ */
+@Suppress("LongParameterList")
+class FirefoxDimens(
+    val grid_0_25: Dp,
+    val grid_0_5: Dp,
+    val grid_1: Dp,
+    val grid_1_5: Dp,
+    val grid_2: Dp,
+    val grid_2_5: Dp,
+    val grid_3: Dp,
+    val grid_3_5: Dp,
+    val grid_4: Dp,
+    val grid_4_5: Dp,
+    val grid_5: Dp,
+    val grid_5_5: Dp,
+    val grid_6: Dp,
+    val plane_0: Dp,
+    val plane_1: Dp,
+    val plane_2: Dp,
+    val plane_3: Dp,
+    val plane_4: Dp,
+    val plane_5: Dp,
+    val minimumTappableArea: Dp = 48.dp,
+)
+
+/**
+ * These are used for devices with width less than 360dp - Small phones like Nexus One.
+ */
+val smallDimensions = FirefoxDimens(
+    grid_0_25 = 2.dp,
+    grid_0_5 = 3.dp,
+    grid_1 = 6.dp,
+    grid_1_5 = 9.dp,
+    grid_2 = 12.dp,
+    grid_2_5 = 15.dp,
+    grid_3 = 18.dp,
+    grid_3_5 = 21.dp,
+    grid_4 = 24.dp,
+    grid_4_5 = 27.dp,
+    grid_5 = 30.dp,
+    grid_5_5 = 33.dp,
+    grid_6 = 36.dp,
+    plane_0 = 0.dp,
+    plane_1 = 1.dp,
+    plane_2 = 2.dp,
+    plane_3 = 3.dp,
+    plane_4 = 6.dp,
+    plane_5 = 12.dp,
+)
+
+/**
+ * These are used for devices with width more than 360dp - Usual phones like Pixel (1-7). Default
+ * implementation of an 8dp grid system. Smaller components can align to a 2dp 'sub' grid.
+ */
+val sw360Dimensions = FirefoxDimens(
+    grid_0_25 = 2.dp,
+    grid_0_5 = 4.dp,
+    grid_1 = 8.dp,
+    grid_1_5 = 12.dp,
+    grid_2 = 16.dp,
+    grid_2_5 = 20.dp,
+    grid_3 = 24.dp,
+    grid_3_5 = 28.dp,
+    grid_4 = 32.dp,
+    grid_4_5 = 36.dp,
+    grid_5 = 40.dp,
+    grid_5_5 = 44.dp,
+    grid_6 = 48.dp,
+    plane_0 = 0.dp,
+    plane_1 = 1.dp,
+    plane_2 = 2.dp,
+    plane_3 = 4.dp,
+    plane_4 = 8.dp,
+    plane_5 = 16.dp,
+)
+
+internal const val SCREEN_WIDTH_THRESHOLD = 360

--- a/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
+++ b/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import mozilla.components.ui.colors.PhotonColors
 import org.mozilla.fenix.compose.inComposePreview
@@ -71,9 +72,17 @@ fun FirefoxTheme(
         Theme.Private -> privateColorPalette
     }
 
+    val configuration = LocalConfiguration.current
+    val dimensions = if (configuration.screenWidthDp <= SCREEN_WIDTH_THRESHOLD) smallDimensions else sw360Dimensions
+
     ProvideFirefoxColors(colors) {
         MaterialTheme(
-            content = content,
+            content = {
+                ProvideFirefoxDimens(
+                    dimens = dimensions,
+                    content = content,
+                )
+            },
         )
     }
 }
@@ -85,6 +94,21 @@ object FirefoxTheme {
 
     val typography: FenixTypography
         get() = defaultTypography
+
+    val dimens: FirefoxDimens
+        @Composable
+        get() = LocalDimens.current
+}
+
+private val LocalDimens = staticCompositionLocalOf { sw360Dimensions }
+
+@Composable
+private fun ProvideFirefoxDimens(
+    dimens: FirefoxDimens,
+    content: @Composable () -> Unit,
+) {
+    val dimensionSet = remember { dimens }
+    CompositionLocalProvider(LocalDimens provides dimensionSet, content = content)
 }
 
 private val darkColorPalette = FirefoxColors(

--- a/app/src/test/java/org/mozilla/fenix/onboarding/OnboardingViewModelTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/onboarding/OnboardingViewModelTest.kt
@@ -1,0 +1,101 @@
+package org.mozilla.fenix.onboarding
+
+import app.cash.turbine.test
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.onboarding.view.OnboardingNavigationEvent
+import org.mozilla.fenix.onboarding.view.OnboardingScreenState
+import org.mozilla.fenix.onboarding.view.OnboardingState
+import org.mozilla.fenix.onboarding.view.OnboardingViewModel
+
+class OnboardingViewModelTest {
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
+    private val tested = OnboardingViewModel()
+
+    @Test
+    fun `on launch state should update to include isUserSignedIn`() {
+        tested.onLaunch(false)
+
+        val expected = OnboardingScreenState.Content(
+            isUserSignedIn = false,
+            onboardingState = OnboardingState.Welcome,
+        )
+
+        assertEquals(expected, tested.state.value)
+    }
+
+    @Test
+    fun `update state to sign in onPrimaryButtonClick when onboardingState is Welcome`() =
+        runTestOnMain {
+            tested.onLaunch(false)
+            val initial = OnboardingScreenState.Content(
+                isUserSignedIn = false,
+                onboardingState = OnboardingState.Welcome,
+            )
+            assertEquals(initial, tested.state.value)
+
+            tested.onPrimaryButtonClick()
+            val expected = OnboardingScreenState.Content(
+                isUserSignedIn = false,
+                onboardingState = OnboardingState.SyncSignIn,
+            )
+
+            assertEquals(expected, tested.state.value)
+        }
+
+    @Test
+    fun `dismiss dialog onPrimaryButtonClick when onboardingState is Welcome and isUserSignedIn is true`() =
+        runTestOnMain {
+            tested.onLaunch(true)
+            val initial = OnboardingScreenState.Content(
+                isUserSignedIn = true,
+                onboardingState = OnboardingState.Welcome,
+            )
+            assertEquals(initial, tested.state.value)
+
+            tested.navigationEvent.test {
+                tested.onPrimaryButtonClick()
+                assertEquals(OnboardingNavigationEvent.DISMISS, awaitItem())
+            }
+        }
+
+    @Test
+    fun `navigate to signIn onPrimaryButtonClick when onboardingState is SyncSignIn`() =
+        runTestOnMain {
+            tested.onLaunch(false)
+            val preTestState = OnboardingScreenState.Content(
+                isUserSignedIn = false,
+                onboardingState = OnboardingState.SyncSignIn,
+            )
+            tested.onPrimaryButtonClick()
+            assertEquals(preTestState, tested.state.value)
+
+            tested.navigationEvent.test {
+                tested.onPrimaryButtonClick()
+                assertEquals(OnboardingNavigationEvent.SIGN_IN, awaitItem())
+            }
+        }
+
+    @Test
+    fun `dismiss dialog onSecondaryButtonClick when onboardingState is SyncSignIn`() =
+        runTestOnMain {
+            tested.onLaunch(false)
+            val preTestState = OnboardingScreenState.Content(
+                isUserSignedIn = false,
+                onboardingState = OnboardingState.SyncSignIn,
+            )
+            tested.onPrimaryButtonClick()
+            assertEquals(preTestState, tested.state.value)
+
+            tested.navigationEvent.test {
+                tested.onSecondaryButtonClick()
+                assertEquals(OnboardingNavigationEvent.DISMISS, awaitItem())
+            }
+        }
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -50,6 +50,7 @@ object FenixVersions {
 
     const val junit = "5.5.2"
     const val mockk = "1.12.0"
+    const val cashapp_turbine = "0.12.1"
 
     const val mockwebserver = "4.10.0"
     const val uiautomator = "2.2.0"
@@ -72,6 +73,7 @@ object FenixDependencies {
     const val kotlin_reflect = "org.jetbrains.kotlin:kotlin-reflect:${FenixVersions.kotlin}"
     const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${FenixVersions.coroutines}"
     const val kotlin_coroutines_test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${FenixVersions.coroutines}"
+    const val cashapp_turbine = "app.cash.turbine:turbine:${FenixVersions.cashapp_turbine}"
     const val kotlin_coroutines_android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${FenixVersions.coroutines}"
 
     const val osslicenses_plugin = "com.google.android.gms:oss-licenses-plugin:${FenixVersions.osslicenses_plugin}"


### PR DESCRIPTION
### What
– Introduce `FirefoxDimens` with a grid system to use a consistent spacing across the app. It also allows to create multiple variants of dimension sets which can be used for different screen sizes. This PR introduces two dimension sets:

- `smallDimensions` – for devices lower than [sw360dp ](https://developer.android.com/guide/topics/large-screens/support-different-screen-sizes#alternative_layout_resources) like Nexus One. There are very small number of devices that fall in this category.
- `sw360Dimensions` - For devices larger than sw360dp like Pixels. 
The same strategy can be used to add dimension sets for tablets like sw600dp and sw720dp. 

This PR initially intended to solve #26929 and adding dimensions set is a fundamental step so I have marked this as draft to get feedback on that. However, feel free to comment/ask questions on the usage of dimensions as well. 

### Extras - can be moved to another PR 
– Move the state to ViewModel and add tests. Add [turbine](https://github.com/cashapp/turbine) to test `SharedFlow`s.
– Make OnboardingPage reusable which takes `OnboardingPageUiState` and click listeners. The idea was to allow another `OnboardingPage` wit only updating the state mapping in the `ViewModel` and handling the clicks.
– Use [BoxWithConstraints](https://developer.android.com/jetpack/compose/layouts/basics#responsive-layouts) to make the image take 40% of the screen size. Previously it would take the space based on the size defined in the resource.
– Vertical scrolling is still enabled as some locales have longer text and Text doesn't auto size text as of now. Ideally, most devices should not need to scroll.

### Preview Screenshots for width 320dp and height 540dp

| Before | After | 
|------|-------|
|<img width="296" alt="Screenshot 2022-12-30 at 17 19 00" src="https://user-images.githubusercontent.com/38040960/210094527-b6ea0785-4583-4a73-ba48-8a58038e4502.png">|<img width="221" alt="Screenshot 2022-12-30 at 17 19 12" src="https://user-images.githubusercontent.com/38040960/210094551-98157f05-3acd-4b62-97ff-77d0d1ebb6ce.png">


### Annotation for checking multiple size previews
```
@Preview(name = "small", widthDp = 240, heightDp = 400)
@Preview(name = "small", widthDp = 240, heightDp = 400, locale = "de")
@Preview(name = "medium", widthDp = 320, heightDp = 540)
@Preview(name = "default")
@Preview(name = "pixel", device = Devices.PIXEL)
@Preview(name = "nexus 5", device = Devices.NEXUS_5)
@Preview(name = "tablet", device = Devices.TABLET)
annotation class MultiDevicePreview

```

### Notes
– [Window Size Classes](https://developer.android.com/guide/topics/large-screens/support-different-screen-sizes#alternative_layout_resources) is another complimentary strategy to build responsive layouts for a large percentage of device sizes in different configurations.
– This got bigger as some fundamental additions were needed 😅 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #26929