### PR TITLE
Bug #1807716: Fix for launch crash on Huawei and other devices

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -203,6 +203,11 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
         ProfilerMarkerFactProcessor.create { components.core.engine.profiler }.register()
 
         run {
+            // Make sure the engine is initialized and ready to use.
+            components.strictMode.resetAfter(StrictMode.allowThreadDiskReads()) {
+                components.core.engine.warmUp()
+            }
+
             // We need to always initialize Glean and do it early here.
             initializeGlean()
 
@@ -213,10 +218,6 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             components.strictMode.enableStrictMode(true)
             warmBrowsersCache()
 
-            // Make sure the engine is initialized and ready to use.
-            components.strictMode.resetAfter(StrictMode.allowThreadDiskReads()) {
-                components.core.engine.warmUp()
-            }
             initializeWebExtensionSupport()
             if (FeatureFlags.storageMaintenanceFeature) {
                 // Make sure to call this function before registering a storage worker


### PR DESCRIPTION
Fixes launch crash for Bugzilla [1807716](https://bugzilla.mozilla.org/show_bug.cgi?id=1807716). 

The pushlog doesn't show any changes in Fenix or GV which would have caused this crash and it is only reproducible when using GV artifacts after linking it to Fenix. There was likely a change in Glean or somewhere else that is causing the crash but one way we can fix the launch crash which is also technically correct is to initialize the runtime earlier instead of doing it in Glean init. 

This also has the added benefit of the crash reporter catching the current crash. 

1807716 will still need to be investigated for root cause.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #1807716