### PR TITLE
For EXP-2992: Add notification config with polling interval to messaging feature

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -37,6 +37,9 @@ messaging:
     messages:
       type: json
       description: A growable collection of messages
+    notification-config:
+      type: json
+      description: Configuration of the notification worker for all notification messages.
     on-control:
       type: string
       description: What should be displayed when a control message is selected.

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -113,6 +113,10 @@ features:
         type: ControlMessageBehavior
         description: What should be displayed when a control message is selected.
         default: show-next-message
+      notification-config:
+        description: Configuration of the notification worker for all notification messages.
+        type: NotificationConfig
+        default: {}
     defaults:
       - value:
           triggers:
@@ -181,6 +185,9 @@ features:
             EXPIRES_QUICKLY:
               priority: 100
               max-display-count: 1
+          notification-config:
+            polling-interval: 180 # 3 minutes
+
   mr2022:
     description: Features for MR 2022.
     variables:
@@ -330,6 +337,15 @@ types:
             How many sessions will this message be shown to the user
             before it is expired.
           default: 5
+    NotificationConfig:
+      description: Attributes controlling the global configuration of notification messages.
+      fields:
+        polling-interval:
+          type: Int
+          description: >
+            How often, in seconds, the notification message worker will wake up and check for new
+            messages.
+          default: 3600
 
   enums:
     ControlMessageBehavior:


### PR DESCRIPTION
Fixes [EXP-2992](https://mozilla-hub.atlassian.net/browse/EXP-2992).

Adds a polling interval to the messaging feature.

This can be accessed via 

```kotlin
val featureConfig = FxNimbus.features.messaging.value()
val notificationConfig = featureConfig.notificationConfig

val pollingInterval = notificationConfig.pollingInterval
```

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
