### PR TITLE
Bug 1808338 - Update Sentry to version 6.11.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -14,7 +14,7 @@ object FenixVersions {
     const val android_gradle_plugin = "7.3.0"
     const val android_lint_api = "30.3.0"
 
-    const val sentry = "6.8.0"
+    const val sentry = "6.11.0"
     const val leakcanary = "2.10"
     const val osslicenses_plugin = "0.10.4"
     const val detekt = "1.19.0"


### PR DESCRIPTION
See the bug for changelog links.