### PR TITLE
For #23841: Hide keyboard when selecting month or year

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorFragment.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.settings.creditcards
 
+import android.annotation.SuppressLint
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.Menu
@@ -56,6 +57,7 @@ class CreditCardEditorFragment :
 
     private lateinit var interactor: CreditCardEditorInteractor
 
+    @SuppressLint("ClickableViewAccessibility")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -81,10 +83,20 @@ class CreditCardEditorFragment :
             creditCardEditorView = CreditCardEditorView(binding, interactor)
             creditCardEditorView.bind(creditCardEditorState)
 
-            binding.cardNumberInput.apply {
-                requestFocus()
-                placeCursorAtEnd()
-                showKeyboard()
+            binding.apply {
+                cardNumberInput.apply {
+                    requestFocus()
+                    placeCursorAtEnd()
+                    showKeyboard()
+                }
+                expiryMonthDropDown.setOnTouchListener { view, _ ->
+                    view?.hideKeyboard()
+                    false
+                }
+                expiryYearDropDown.setOnTouchListener { view, _ ->
+                    view?.hideKeyboard()
+                    false
+                }
             }
         }
     }


### PR DESCRIPTION
CI for https://github.com/mozilla-mobile/fenix/pull/23892

Fixes #23841