### PR TITLE
Bug 1807302 - New set desktop site before page load UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -141,7 +141,7 @@ class ReaderViewTest {
             verifyReaderViewDetected(true)
         }.openThreeDotMenu {
             verifyReaderViewAppearance(false)
-        }.close { }
+        }.closeBrowserMenuToBrowser { }
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
@@ -11,6 +11,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.ui.robots.homeScreen
 
 /**
@@ -136,6 +137,63 @@ class ThreeDotMenuMainTest {
         }.openThreeDotMenu {
         }.openSettings {
             verifySettingsView()
+        }
+    }
+
+    @Test
+    fun setDesktopSiteBeforePageLoadTest() {
+        val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 4)
+
+        homeScreen {
+        }.openThreeDotMenu {
+            verifyDesktopSiteModeEnabled(false)
+        }.switchDesktopSiteMode {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.openThreeDotMenu {
+            verifyDesktopSiteModeEnabled(true)
+        }.closeBrowserMenuToBrowser {
+            clickLinkMatchingText("Link 1")
+        }.openThreeDotMenu {
+            verifyDesktopSiteModeEnabled(true)
+        }.closeBrowserMenuToBrowser {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+            longClickLink("Link 2")
+            clickContextOpenLinkInNewTab()
+            snackBarButtonClick()
+        }.openThreeDotMenu {
+            verifyDesktopSiteModeEnabled(false)
+        }
+    }
+
+    @Test
+    fun privateBrowsingSetDesktopSiteBeforePageLoadTest() {
+        val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 4)
+
+        homeScreen {
+        }.togglePrivateBrowsingMode()
+
+        homeScreen {
+        }.openThreeDotMenu {
+            verifyDesktopSiteModeEnabled(false)
+        }.switchDesktopSiteMode {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.openThreeDotMenu {
+            verifyDesktopSiteModeEnabled(true)
+        }.closeBrowserMenuToBrowser {
+            clickLinkMatchingText("Link 1")
+        }.openThreeDotMenu {
+            verifyDesktopSiteModeEnabled(true)
+        }.closeBrowserMenuToBrowser {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+            longClickLink("Link 2")
+            clickContextOpenLinkInPrivateTab()
+            snackBarButtonClick()
+        }.openThreeDotMenu {
+            verifyDesktopSiteModeEnabled(false)
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -274,14 +274,6 @@ class ThreeDotMenuMainRobot {
             return ShareOverlayRobot.Transition()
         }
 
-        fun close(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
-            // Close three dot
-            mDevice.pressBack()
-
-            HomeScreenRobot().interact()
-            return HomeScreenRobot.Transition()
-        }
-
         fun closeBrowserMenuToBrowser(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             // Close three dot
             mDevice.pressBack()


### PR DESCRIPTION
Bug 1807302 - New set desktop site before page load UI tests.

`setDesktopSiteBeforePageLoadTest` ✅ successfully passed 100x on Firebase
`privateBrowsingSetDesktopSiteBeforePageLoadTest` ✅ successfully passed 100x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
