### PR TITLE
Closes 28414: NotificationManagerCompat extension to safely check if notifications are enabled

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/NotificationManagerCompat.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/NotificationManagerCompat.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ext
+
+import androidx.core.app.NotificationManagerCompat
+
+/**
+ * Returns whether notifications are enabled, catches any exception that was thrown from
+ * [NotificationManagerCompat.areNotificationsEnabled] and returns false.
+ */
+@Suppress("TooGenericExceptionCaught")
+fun NotificationManagerCompat.areNotificationsEnabledSafe(): Boolean {
+    return try {
+        areNotificationsEnabled()
+    } catch (e: Exception) {
+        false
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/onboarding/MarketingNotificationHelper.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/MarketingNotificationHelper.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import androidx.core.app.NotificationManagerCompat
 import org.mozilla.fenix.GleanMetrics.Events.marketingNotificationAllowed
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.areNotificationsEnabledSafe
 
 // Channel ID was not updated when it was renamed to marketing.  Thus, we'll have to continue
 // to use this ID as the marketing channel ID
@@ -47,12 +48,7 @@ fun ensureMarketingChannelExists(context: Context): String {
         channelEnabled = channel.importance != NotificationManager.IMPORTANCE_NONE
     }
 
-    @Suppress("TooGenericExceptionCaught")
-    val notificationsEnabled = try {
-        NotificationManagerCompat.from(context).areNotificationsEnabled()
-    } catch (e: Exception) {
-        false
-    }
+    val notificationsEnabled = NotificationManagerCompat.from(context).areNotificationsEnabledSafe()
 
     marketingNotificationAllowed.set(notificationsEnabled && channelEnabled)
 


### PR DESCRIPTION
- Checks if notifications are enabled, this extracts the block from `ensureMarketingChannelExists` as it can/will be used in other places as part of the pre-permission notification work. 
– No tests as the logic is fairly straightforward.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
