### PR TITLE
Closes 28417: Add nimbus flags for pre permission prompt

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -71,6 +71,14 @@ nimbus-validation:
     settings-title:
       type: string
       description: The title of displayed in the Settings screen and app menu.
+pre-permission-notification-prompt:
+  description: A feature that shows the pre-permission notification prompt.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "if true, the pre-permission notification prompt is shown to the user."
 re-engagement-notification:
   description: A feature that shows the re-enagement notification if the user is inactive.
   hasExposure: true

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -265,6 +265,14 @@ features:
         type: Boolean
         default: true
 
+  pre-permission-notification-prompt:
+    description: A feature that shows the pre-permission notification prompt.
+    variables:
+      enabled:
+        description: if true, the pre-permission notification prompt is shown to the user.
+        type: Boolean
+        default: true
+
 types:
   objects:
     MessageData:


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
