### PR TITLE
EXP 2991: Add surface to messaging fml

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -36,6 +36,7 @@ import org.mozilla.fenix.gleanplumb.state.MessagingMiddleware
 import org.mozilla.fenix.home.PocketUpdatesMiddleware
 import org.mozilla.fenix.home.blocklist.BlocklistHandler
 import org.mozilla.fenix.home.blocklist.BlocklistMiddleware
+import org.mozilla.fenix.nimbus.MessageSurfaceId
 import org.mozilla.fenix.perf.AppStartReasonProvider
 import org.mozilla.fenix.perf.StartupActivityLog
 import org.mozilla.fenix.perf.StartupStateProvider
@@ -207,7 +208,10 @@ class Components(private val context: Context) {
                     core.pocketStoriesService,
                     context.pocketStoriesSelectedCategoriesDataStore,
                 ),
-                MessagingMiddleware(messagingStorage = analytics.messagingStorage),
+                MessagingMiddleware(
+                    surface = MessageSurfaceId.HOMESCREEN,
+                    messagingStorage = analytics.messagingStorage
+                ),
                 MetricsMiddleware(metrics = analytics.metrics),
             ),
         )

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -209,7 +209,6 @@ class Components(private val context: Context) {
                     context.pocketStoriesSelectedCategoriesDataStore,
                 ),
                 MessagingMiddleware(
-                    surface = MessageSurfaceId.HOMESCREEN,
                     messagingStorage = analytics.messagingStorage,
                 ),
                 MetricsMiddleware(metrics = analytics.metrics),

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -36,7 +36,6 @@ import org.mozilla.fenix.gleanplumb.state.MessagingMiddleware
 import org.mozilla.fenix.home.PocketUpdatesMiddleware
 import org.mozilla.fenix.home.blocklist.BlocklistHandler
 import org.mozilla.fenix.home.blocklist.BlocklistMiddleware
-import org.mozilla.fenix.nimbus.MessageSurfaceId
 import org.mozilla.fenix.perf.AppStartReasonProvider
 import org.mozilla.fenix.perf.StartupActivityLog
 import org.mozilla.fenix.perf.StartupStateProvider

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -210,7 +210,7 @@ class Components(private val context: Context) {
                 ),
                 MessagingMiddleware(
                     surface = MessageSurfaceId.HOMESCREEN,
-                    messagingStorage = analytics.messagingStorage
+                    messagingStorage = analytics.messagingStorage,
                 ),
                 MetricsMiddleware(metrics = analytics.metrics),
             ),

--- a/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
@@ -22,6 +22,7 @@ import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
 import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
 import org.mozilla.fenix.library.history.PendingDeletionHistory
+import org.mozilla.fenix.nimbus.MessageSurfaceId
 import org.mozilla.fenix.wallpapers.Wallpaper
 
 /**
@@ -137,7 +138,7 @@ sealed class AppAction : Action {
         /**
          * Evaluates if a new messages should be shown to users.
          */
-        object Evaluate : MessagingAction()
+        data class Evaluate(val surface: MessageSurfaceId) : MessagingAction()
 
         /**
          * Updates [MessagingState.messageToShow] with the given [message].
@@ -147,7 +148,7 @@ sealed class AppAction : Action {
         /**
          * Updates [MessagingState.messageToShow] with the given [message].
          */
-        object ConsumeMessageToShow : MessagingAction()
+        data class ConsumeMessageToShow(val surface: MessageSurfaceId) : MessagingAction()
 
         /**
          * Updates [MessagingState.messages] with the given [messages].

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/Message.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/Message.kt
@@ -34,6 +34,9 @@ data class Message(
     val priority: Int
         get() = style.priority
 
+    val surface: MessageSurfaceId
+        get() = data.surface
+
     /**
      * A data class that holds metadata that help to identify if a message should shown.
      *

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/Message.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/Message.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.gleanplumb
 
 import org.mozilla.fenix.nimbus.MessageData
+import org.mozilla.fenix.nimbus.MessageSurfaceId
 import org.mozilla.fenix.nimbus.StyleData
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/MessagingFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/MessagingFeature.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.gleanplumb
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction.MessagingAction
+import org.mozilla.fenix.nimbus.MessageSurfaceId
 
 /**
  * A message observer that updates the provided.
@@ -14,7 +15,7 @@ import org.mozilla.fenix.components.appstate.AppAction.MessagingAction
 class MessagingFeature(val appStore: AppStore) : LifecycleAwareFeature {
 
     override fun start() {
-        appStore.dispatch(MessagingAction.Evaluate)
+        appStore.dispatch(MessagingAction.Evaluate(MessageSurfaceId.HOMESCREEN))
     }
 
     override fun stop() = Unit

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/MessagingState.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/MessagingState.kt
@@ -4,6 +4,8 @@
 
 package org.mozilla.fenix.gleanplumb
 
+import org.mozilla.fenix.nimbus.MessageSurfaceId
+
 /**
  * Represent all the state related to the Messaging framework.
  * @param messages Indicates all the available messages.
@@ -12,5 +14,5 @@ package org.mozilla.fenix.gleanplumb
  */
 data class MessagingState(
     val messages: List<Message> = emptyList(),
-    val messageToShow: Message? = null,
+    val messageToShow: Map<MessageSurfaceId, Message> = emptyMap(),
 )

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorage.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorage.kt
@@ -92,8 +92,7 @@ class NimbusMessagingStorage(
         val jexlCache = HashMap<String, Boolean>()
         val helper = gleanPlumb.createMessageHelper(customAttributes)
         val message = availableMessages.firstOrNull {
-            surface == it.surface &&
-            isMessageEligible(it, helper, jexlCache)
+            surface == it.surface && isMessageEligible(it, helper, jexlCache)
         } ?: return null
 
         // Check this isn't an experimental message. If not, we can go ahead and return it.

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorage.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorage.kt
@@ -55,7 +55,7 @@ class NimbusMessagingStorage(
     /**
      * Returns a list of available messages descending sorted by their priority.
      */
-    suspend fun getMessages(surface: MessageSurfaceId): List<Message> {
+    suspend fun getMessages(): List<Message> {
         val nimbusTriggers = nimbusFeature.triggers
         val nimbusStyles = nimbusFeature.styles
         val nimbusActions = nimbusFeature.actions
@@ -65,7 +65,6 @@ class NimbusMessagingStorage(
         val storageMetadata = metadataStorage.getMetadata()
 
         return nimbusMessages
-            .filterValues { surface == it.surface }
             .mapNotNull { (key, value) ->
                 val action = sanitizeAction(key, value.action, nimbusActions, value.isControl) ?: return@mapNotNull null
                 Message(
@@ -89,10 +88,11 @@ class NimbusMessagingStorage(
     /**
      * Returns the next higher priority message which all their triggers are true.
      */
-    fun getNextMessage(availableMessages: List<Message>): Message? {
+    fun getNextMessage(surface: MessageSurfaceId, availableMessages: List<Message>): Message? {
         val jexlCache = HashMap<String, Boolean>()
         val helper = gleanPlumb.createMessageHelper(customAttributes)
         val message = availableMessages.firstOrNull {
+            surface == it.data.surface &&
             isMessageEligible(it, helper, jexlCache)
         } ?: return null
 

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorage.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorage.kt
@@ -92,7 +92,7 @@ class NimbusMessagingStorage(
         val jexlCache = HashMap<String, Boolean>()
         val helper = gleanPlumb.createMessageHelper(customAttributes)
         val message = availableMessages.firstOrNull {
-            surface == it.data.surface &&
+            surface == it.surface &&
             isMessageEligible(it, helper, jexlCache)
         } ?: return null
 

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddleware.kt
@@ -27,6 +27,7 @@ import org.mozilla.fenix.nimbus.MessageSurfaceId
 typealias AppStoreMiddlewareContext = MiddlewareContext<AppState, AppAction>
 
 class MessagingMiddleware(
+    private val surface: MessageSurfaceId,
     private val messagingStorage: NimbusMessagingStorage,
     private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
 ) : Middleware<AppState, AppAction> {
@@ -39,7 +40,7 @@ class MessagingMiddleware(
         when (action) {
             is Restore -> {
                 coroutineScope.launch {
-                    val messages = messagingStorage.getMessages(MessageSurfaceId.HOMESCREEN)
+                    val messages = messagingStorage.getMessages(surface)
                     context.store.dispatch(UpdateMessages(messages))
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddleware.kt
@@ -22,7 +22,6 @@ import org.mozilla.fenix.components.appstate.AppAction.MessagingAction.UpdateMes
 import org.mozilla.fenix.components.appstate.AppState
 import org.mozilla.fenix.gleanplumb.Message
 import org.mozilla.fenix.gleanplumb.NimbusMessagingStorage
-import org.mozilla.fenix.nimbus.MessageSurfaceId
 
 typealias AppStoreMiddlewareContext = MiddlewareContext<AppState, AppAction>
 
@@ -47,7 +46,7 @@ class MessagingMiddleware(
             is Evaluate -> {
                 val message = messagingStorage.getNextMessage(
                     action.surface,
-                    context.state.messaging.messages
+                    context.state.messaging.messages,
                 )
                 if (message != null) {
                     context.dispatch(UpdateMessageToShow(message))

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddleware.kt
@@ -22,6 +22,7 @@ import org.mozilla.fenix.components.appstate.AppAction.MessagingAction.UpdateMes
 import org.mozilla.fenix.components.appstate.AppState
 import org.mozilla.fenix.gleanplumb.Message
 import org.mozilla.fenix.gleanplumb.NimbusMessagingStorage
+import org.mozilla.fenix.nimbus.MessageSurfaceId
 
 typealias AppStoreMiddlewareContext = MiddlewareContext<AppState, AppAction>
 
@@ -38,7 +39,7 @@ class MessagingMiddleware(
         when (action) {
             is Restore -> {
                 coroutineScope.launch {
-                    val messages = messagingStorage.getMessages()
+                    val messages = messagingStorage.getMessages(MessageSurfaceId.HOMESCREEN)
                     context.store.dispatch(UpdateMessages(messages))
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddleware.kt
@@ -139,9 +139,9 @@ class MessagingMiddleware(
         context: AppStoreMiddlewareContext,
         message: Message,
     ) {
-        val current = context.state.messaging.messageToShow[message.data.surface]
+        val current = context.state.messaging.messageToShow[message.surface]
         if (current?.id == message.id) {
-            context.dispatch(ConsumeMessageToShow(message.data.surface))
+            context.dispatch(ConsumeMessageToShow(message.surface))
         }
     }
 
@@ -159,7 +159,7 @@ class MessagingMiddleware(
         oldMessage: Message,
         updatedMessage: Message,
     ): List<Message> {
-        val actualMessageToShow = context.state.messaging.messageToShow.get(updatedMessage.data.surface)
+        val actualMessageToShow = context.state.messaging.messageToShow.get(updatedMessage.surface)
 
         if (actualMessageToShow?.id == oldMessage.id) {
             context.dispatch(UpdateMessageToShow(updatedMessage))

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingReducer.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingReducer.kt
@@ -17,9 +17,11 @@ import org.mozilla.fenix.gleanplumb.MessagingState
 internal object MessagingReducer {
     fun reduce(state: AppState, action: AppAction.MessagingAction): AppState = when (action) {
         is UpdateMessageToShow -> {
+            val messageToShow = state.messaging.messageToShow.toMutableMap()
+            messageToShow[action.message.data.surface] = action.message
             state.copy(
                 messaging = state.messaging.copy(
-                    messageToShow = action.message,
+                    messageToShow = messageToShow,
                 ),
             )
         }
@@ -31,9 +33,11 @@ internal object MessagingReducer {
             )
         }
         is ConsumeMessageToShow -> {
+            val messageToShow = state.messaging.messageToShow.toMutableMap()
+            messageToShow.remove(action.surface)
             state.copy(
                 messaging = state.messaging.copy(
-                    messageToShow = null,
+                    messageToShow = messageToShow,
                 ),
             )
         }

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingReducer.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingReducer.kt
@@ -18,7 +18,7 @@ internal object MessagingReducer {
     fun reduce(state: AppState, action: AppAction.MessagingAction): AppState = when (action) {
         is UpdateMessageToShow -> {
             val messageToShow = state.messaging.messageToShow.toMutableMap()
-            messageToShow[action.message.data.surface] = action.message
+            messageToShow[action.message.surface] = action.message
             state.copy(
                 messaging = state.messaging.copy(
                     messageToShow = messageToShow,

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
@@ -23,6 +23,7 @@ import org.mozilla.fenix.home.Mode
 import org.mozilla.fenix.home.OnboardingState
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
+import org.mozilla.fenix.nimbus.MessageSurfaceId
 import org.mozilla.fenix.onboarding.HomeCFRPresenter
 import org.mozilla.fenix.utils.Settings
 
@@ -167,7 +168,7 @@ private fun AppState.toAdapterList(settings: Settings): List<AdapterItem> = when
         expandedCollections,
         recentBookmarks,
         showCollectionPlaceholder,
-        messaging.messageToShow,
+        messaging.messageToShow[MessageSurfaceId.HOMESCREEN],
         shouldShowRecentTabs(settings),
         shouldShowRecentSyncedTabs(settings),
         recentHistory,

--- a/app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt
@@ -20,8 +20,6 @@ import mozilla.components.service.pocket.PocketStory.PocketSponsoredStory
 import mozilla.components.service.pocket.PocketStory.PocketSponsoredStoryCaps
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -34,6 +32,7 @@ import org.mozilla.fenix.components.appstate.AppState
 import org.mozilla.fenix.components.appstate.filterOut
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getFilteredStories
+import org.mozilla.fenix.gleanplumb.Message
 import org.mozilla.fenix.home.CurrentMode
 import org.mozilla.fenix.home.Mode
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
@@ -45,6 +44,8 @@ import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryHighlight
+import org.mozilla.fenix.nimbus.MessageData
+import org.mozilla.fenix.nimbus.MessageSurfaceId
 import org.mozilla.fenix.onboarding.FenixOnboarding
 
 class AppStoreTest {
@@ -113,11 +114,19 @@ class AppStoreTest {
     @Test
     fun `GIVEN a new value for messageToShow WHEN NimbusMessageChange is called THEN update the current value`() =
         runTest {
-            assertNull(appStore.state.messaging.messageToShow)
+            assertTrue(appStore.state.messaging.messageToShow.isEmpty())
 
-            appStore.dispatch(UpdateMessageToShow(mockk())).join()
+            val message = Message(
+                "message",
+                MessageData(surface = MessageSurfaceId.HOMESCREEN),
+                "action",
+                mockk(),
+                emptyList(),
+                mockk(),
+            )
+            appStore.dispatch(UpdateMessageToShow(message)).join()
 
-            assertNotNull(appStore.state.messaging.messageToShow)
+            assertFalse(appStore.state.messaging.messageToShow.isEmpty())
         }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/MessagingFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/MessagingFeatureTest.kt
@@ -12,6 +12,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction.MessagingAction
+import org.mozilla.fenix.nimbus.MessageSurfaceId
 
 class MessagingFeatureTest {
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -25,6 +26,6 @@ class MessagingFeatureTest {
 
         binding.start()
 
-        verify { appStore.dispatch(MessagingAction.Evaluate) }
+        verify { appStore.dispatch(MessagingAction.Evaluate(MessageSurfaceId.HOMESCREEN)) }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorageTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorageTest.kt
@@ -20,20 +20,19 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.experiments.nimbus.GleanPlumbInterface
 import org.mozilla.experiments.nimbus.GleanPlumbMessageHelper
+import org.mozilla.experiments.nimbus.NullVariables
+import org.mozilla.experiments.nimbus.Res
 import org.mozilla.experiments.nimbus.internal.FeatureHolder
 import org.mozilla.experiments.nimbus.internal.NimbusException
-import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.nimbus.ControlMessageBehavior.SHOW_NEXT_MESSAGE
 import org.mozilla.fenix.nimbus.MessageData
+import org.mozilla.fenix.nimbus.MessageSurfaceId
 import org.mozilla.fenix.nimbus.Messaging
 import org.mozilla.fenix.nimbus.StyleData
 
 @RunWith(FenixRobolectricTestRunner::class)
 class NimbusMessagingStorageTest {
-
-    private val activity: HomeActivity = mockk(relaxed = true)
-    private val storageNimbus: NimbusMessagingStorage = mockk(relaxed = true)
     private lateinit var storage: NimbusMessagingStorage
     private lateinit var metadataStorage: MessageMetadataStorage
     private lateinit var gleanPlumb: GleanPlumbInterface
@@ -49,6 +48,7 @@ class NimbusMessagingStorageTest {
         gleanPlumb = mockk(relaxed = true)
         metadataStorage = mockk(relaxed = true)
         malformedWasReported = false
+        NullVariables.instance.setContext(testContext)
         messagingFeature = createMessagingFeature()
 
         coEvery { metadataStorage.getMetadata() } returns mapOf("message-1" to Message.Metadata(id = "message-1"))
@@ -581,13 +581,13 @@ class NimbusMessagingStorageTest {
         action: String = "action-1",
         style: String = "style-1",
         triggers: List<String> = listOf("trigger-1"),
-    ): MessageData {
-        val messageData1: MessageData = mockk(relaxed = true)
-        every { messageData1.action } returns action
-        every { messageData1.style } returns style
-        every { messageData1.trigger } returns triggers
-        return messageData1
-    }
+        surface: MessageSurfaceId = MessageSurfaceId.HOMESCREEN,
+    ) = MessageData(
+        action = Res.string(action),
+        style = style,
+        trigger = triggers,
+        surface = surface,
+    )
 
     private fun createMessagingFeature(
         triggers: Map<String, String> = mapOf("trigger-1" to "trigger-1-expression"),

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorageTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorageTest.kt
@@ -63,11 +63,14 @@ class NimbusMessagingStorageTest {
     }
 
     @Test
-    fun `WHEN calling getMessages THEN provide a list of available messages`() = runTest {
-        val message = storage.getMessages(MessageSurfaceId.HOMESCREEN).first()
+    fun `WHEN calling getMessages THEN provide a list of available messages for a given surface`() = runTest {
+        val homescreenMessage = storage.getMessages(MessageSurfaceId.HOMESCREEN).first()
 
-        assertEquals("message-1", message.id)
-        assertEquals("message-1", message.metadata.id)
+        assertEquals("message-1", homescreenMessage.id)
+        assertEquals("message-1", homescreenMessage.metadata.id)
+
+        val notificationMessage = storage.getMessages(MessageSurfaceId.NOTIFICATION).first()
+        assertEquals("message-2", notificationMessage.id)
     }
 
     @Test
@@ -594,20 +597,20 @@ class NimbusMessagingStorageTest {
         styles: Map<String, StyleData> = mapOf("style-1" to createStyle()),
         actions: Map<String, String> = mapOf("action-1" to "action-1-url"),
         messages: Map<String, MessageData> = mapOf(
-            "message-1" to createMessageData(),
-            "malformed" to mockk(relaxed = true),
+            "message-1" to createMessageData(surface = MessageSurfaceId.HOMESCREEN),
+            "message-2" to createMessageData(surface = MessageSurfaceId.NOTIFICATION),
+            "malformed" to createMessageData(action = "malformed-action"),
         ),
     ): FeatureHolder<Messaging> {
         val messagingFeature: FeatureHolder<Messaging> = mockk(relaxed = true)
-
-        messaging = mockk(relaxed = true)
-
-        every { messaging.triggers } returns triggers
-        every { messaging.styles } returns styles
-        every { messaging.actions } returns actions
-        every { messaging.messages } returns messages
-
+        messaging = Messaging(
+            actions = actions,
+            triggers = triggers,
+            messages = messages,
+            styles = styles,
+        )
         every { messagingFeature.value() } returns messaging
+
         return messagingFeature
     }
 

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorageTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorageTest.kt
@@ -64,7 +64,7 @@ class NimbusMessagingStorageTest {
 
     @Test
     fun `WHEN calling getMessages THEN provide a list of available messages`() = runTest {
-        val message = storage.getMessages().first()
+        val message = storage.getMessages(MessageSurfaceId.HOMESCREEN).first()
 
         assertEquals("message-1", message.id)
         assertEquals("message-1", message.metadata.id)
@@ -103,7 +103,7 @@ class NimbusMessagingStorageTest {
                 messagingFeature,
             )
 
-            val results = storage.getMessages()
+            val results = storage.getMessages(MessageSurfaceId.HOMESCREEN)
 
             assertEquals("high-message", results[0].id)
             assertEquals("medium-message", results[1].id)
@@ -140,7 +140,7 @@ class NimbusMessagingStorageTest {
                 messagingFeature,
             )
 
-            val results = storage.getMessages()
+            val results = storage.getMessages(MessageSurfaceId.HOMESCREEN)
 
             assertEquals(1, results.size)
             assertEquals("normal-message", results[0].id)
@@ -176,7 +176,7 @@ class NimbusMessagingStorageTest {
                 messagingFeature,
             )
 
-            val results = storage.getMessages()
+            val results = storage.getMessages(MessageSurfaceId.HOMESCREEN)
 
             assertEquals(1, results.size)
             assertEquals("normal-message", results[0].id)
@@ -217,7 +217,7 @@ class NimbusMessagingStorageTest {
                 messagingFeature,
             )
 
-            val results = storage.getMessages()
+            val results = storage.getMessages(MessageSurfaceId.HOMESCREEN)
 
             assertEquals(1, results.size)
             assertEquals("normal-message", results[0].id)
@@ -225,7 +225,7 @@ class NimbusMessagingStorageTest {
 
     @Test
     fun `GIVEN a malformed message WHEN calling getMessages THEN provide a list of messages ignoring the malformed one`() = runTest {
-        val messages = storage.getMessages()
+        val messages = storage.getMessages(MessageSurfaceId.HOMESCREEN)
         val firstMessage = messages.first()
 
         assertEquals("message-1", firstMessage.id)

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorageTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorageTest.kt
@@ -570,8 +570,10 @@ class NimbusMessagingStorageTest {
         every { spiedStorage.isMessageEligible(any(), any()) } returns true
         every { spiedStorage.isMessageUnderExperiment(any(), any()) } returns true
 
-        val result = spiedStorage.getNextMessage(MessageSurfaceId.HOMESCREEN,
-            listOf(controlMessage, message))
+        val result = spiedStorage.getNextMessage(
+            MessageSurfaceId.HOMESCREEN,
+            listOf(controlMessage, message),
+        )
 
         verify { messagingFeature.recordExposure() }
         assertEquals(message.id, result!!.id)

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddlewareTest.kt
@@ -61,6 +61,7 @@ class MessagingMiddlewareTest {
         every { middlewareContext.store } returns appStore
 
         middleware = MessagingMiddleware(
+            surface = MessageSurfaceId.HOMESCREEN,
             messagingStorage,
             coroutineScope,
         )

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddlewareTest.kt
@@ -228,13 +228,13 @@ class MessagingMiddlewareTest {
         val appState: AppState = mockk(relaxed = true)
         val messagingState: MessagingState = mockk(relaxed = true)
 
-        every { messagingState.messageToShow } returns mapOf(message.data.surface to message)
+        every { messagingState.messageToShow } returns mapOf(message.surface to message)
         every { appState.messaging } returns messagingState
         every { middlewareContext.state } returns appState
 
         middleware.consumeMessageToShowIfNeeded(middlewareContext, message)
 
-        verify { middlewareContext.dispatch(ConsumeMessageToShow(message.data.surface)) }
+        verify { middlewareContext.dispatch(ConsumeMessageToShow(message.surface)) }
     }
 
     @Test
@@ -262,7 +262,7 @@ class MessagingMiddlewareTest {
         val appState: AppState = mockk(relaxed = true)
         val messagingState: MessagingState = mockk(relaxed = true)
 
-        every { messagingState.messageToShow } returns mapOf(oldMessage.data.surface to oldMessage)
+        every { messagingState.messageToShow } returns mapOf(oldMessage.surface to oldMessage)
         every { appState.messaging } returns messagingState
         every { middlewareContext.state } returns appState
         every { spiedMiddleware.removeMessage(middlewareContext, oldMessage) } returns emptyList()

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddlewareTest.kt
@@ -37,6 +37,7 @@ import org.mozilla.fenix.gleanplumb.MessagingState
 import org.mozilla.fenix.gleanplumb.NimbusMessagingStorage
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.nimbus.MessageData
+import org.mozilla.fenix.nimbus.MessageSurfaceId
 import org.mozilla.fenix.nimbus.StyleData
 
 @RunWith(FenixRobolectricTestRunner::class)
@@ -69,7 +70,7 @@ class MessagingMiddlewareTest {
     fun `WHEN Restore THEN get messages from the storage and UpdateMessages`() = runTestOnMain {
         val messages: List<Message> = emptyList()
 
-        coEvery { messagingStorage.getMessages() } returns messages
+        coEvery { messagingStorage.getMessages(MessageSurfaceId.HOMESCREEN) } returns messages
 
         middleware.invoke(middlewareContext, {}, Restore)
 

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingReducerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingReducerTest.kt
@@ -31,7 +31,7 @@ class MessagingReducerTest {
             ),
         )
 
-        val m = createMessage("message-1")
+        val m = createMessage("message1")
 
         var updatedState = MessagingReducer.reduce(
             initialState,

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingReducerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingReducerTest.kt
@@ -52,7 +52,7 @@ class MessagingReducerTest {
             action = action,
             style = StyleData(),
             triggers = listOf(),
-            metadata = Message.Metadata(id = id)
+            metadata = Message.Metadata(id = id),
         )
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingReducerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingReducerTest.kt
@@ -15,7 +15,11 @@ import org.mozilla.fenix.components.appstate.AppAction.MessagingAction.UpdateMes
 import org.mozilla.fenix.components.appstate.AppAction.MessagingAction.UpdateMessages
 import org.mozilla.fenix.components.appstate.AppState
 import org.mozilla.fenix.components.appstate.AppStoreReducer
+import org.mozilla.fenix.gleanplumb.Message
 import org.mozilla.fenix.gleanplumb.MessagingState
+import org.mozilla.fenix.nimbus.MessageData
+import org.mozilla.fenix.nimbus.MessageSurfaceId
+import org.mozilla.fenix.nimbus.StyleData
 
 class MessagingReducerTest {
 
@@ -23,21 +27,33 @@ class MessagingReducerTest {
     fun `GIVEN a new value for messageToShow WHEN UpdateMessageToShow is called THEN update the current value`() {
         val initialState = AppState(
             messaging = MessagingState(
-                messageToShow = null,
+                messageToShow = mapOf(),
             ),
         )
 
+        val m = createMessage("message-1")
+
         var updatedState = MessagingReducer.reduce(
             initialState,
-            UpdateMessageToShow(mockk()),
+            UpdateMessageToShow(m),
         )
 
-        assertNotNull(updatedState.messaging.messageToShow)
+        assertNotNull(updatedState.messaging.messageToShow[m.data.surface])
 
-        updatedState = AppStoreReducer.reduce(updatedState, ConsumeMessageToShow)
+        updatedState = AppStoreReducer.reduce(updatedState, ConsumeMessageToShow(m.data.surface))
 
-        assertNull(updatedState.messaging.messageToShow)
+        assertNull(updatedState.messaging.messageToShow[m.data.surface])
     }
+
+    private fun createMessage(id: String, action: String = "action-1", surface: MessageSurfaceId = MessageSurfaceId.HOMESCREEN): Message =
+        Message(
+            id = id,
+            data = MessageData(surface = surface),
+            action = action,
+            style = StyleData(),
+            triggers = listOf(),
+            metadata = Message.Metadata(id = id)
+        )
 
     @Test
     fun `GIVEN a new value for messages WHEN UpdateMessages is called THEN update the current value`() {

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingReducerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/state/MessagingReducerTest.kt
@@ -38,11 +38,11 @@ class MessagingReducerTest {
             UpdateMessageToShow(m),
         )
 
-        assertNotNull(updatedState.messaging.messageToShow[m.data.surface])
+        assertNotNull(updatedState.messaging.messageToShow[m.surface])
 
-        updatedState = AppStoreReducer.reduce(updatedState, ConsumeMessageToShow(m.data.surface))
+        updatedState = AppStoreReducer.reduce(updatedState, ConsumeMessageToShow(m.surface))
 
-        assertNull(updatedState.messaging.messageToShow[m.data.surface])
+        assertNull(updatedState.messaging.messageToShow[m.surface])
     }
 
     private fun createMessage(id: String, action: String = "action-1", surface: MessageSurfaceId = MessageSurfaceId.HOMESCREEN): Message =

--- a/messaging.fml.yaml
+++ b/messaging.fml.yaml
@@ -155,6 +155,11 @@ objects:
           The style as described in a
           `StyleData` from the styles table.
         default: DEFAULT
+      surface:
+        description:
+          The surface identifier for this message.
+        type: MessageSurfaceId
+        default: homescreen
       trigger:
         type: List<String>
         description: >
@@ -197,3 +202,10 @@ enums:
         description: The next eligible message should be shown.
       show-none:
         description: The surface should show no message.
+  MessageSurfaceId:
+    description: The identity of a message surface
+    variants:
+      homescreen:
+        description: A banner in the homescreen.
+      notification:
+        description: A local notification in the background, like a push notification.

--- a/messaging.fml.yaml
+++ b/messaging.fml.yaml
@@ -1,0 +1,199 @@
+---
+features:
+  messaging:
+    description: |
+      Configuration for the messaging system.
+
+      In practice this is a set of growable lookup tables for the
+      message controller to piece together.
+
+    variables:
+      message-under-experiment:
+        description: Id or prefix of the message under experiment.
+        type: Option<String>
+        default: null
+
+      messages:
+        description: A growable collection of messages
+        type: Map<String, MessageData>
+        default: {}
+
+      triggers:
+        description: >
+          A collection of out the box trigger
+          expressions. Each entry maps to a
+          valid JEXL expression.
+        type: Map<String, String>
+        default: {}
+      styles:
+        description: >
+          A map of styles to configure message
+          appearance.
+        type: Map<String, StyleData>
+        default: {}
+
+      actions:
+        type: Map<String, String>
+        description: A growable map of action URLs.
+        default: {}
+      on-control:
+        type: ControlMessageBehavior
+        description: What should be displayed when a control message is selected.
+        default: show-next-message
+      notification-config:
+        description: Configuration of the notification worker for all notification messages.
+        type: NotificationConfig
+        default: {}
+    defaults:
+      - value:
+          triggers:
+            USER_RECENTLY_INSTALLED: days_since_install < 7
+            USER_RECENTLY_UPDATED: days_since_update < 7 && days_since_install != days_since_update
+            USER_TIER_ONE_COUNTRY: ('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)
+            USER_EN_SPEAKER: "'en' in locale"
+            USER_DE_SPEAKER: "'de' in locale"
+            USER_FR_SPEAKER: "'fr' in locale"
+            DEVICE_ANDROID: os == 'Android'
+            DEVICE_IOS: os == 'iOS'
+            ALWAYS: "true"
+            NEVER: "false"
+            I_AM_DEFAULT_BROWSER: "is_default_browser"
+            I_AM_NOT_DEFAULT_BROWSER: "is_default_browser == false"
+            USER_ESTABLISHED_INSTALL: "number_of_app_launches >=4"
+          actions:
+            ENABLE_PRIVATE_BROWSING: ://enable_private_browsing
+            INSTALL_SEARCH_WIDGET: ://install_search_widget
+            MAKE_DEFAULT_BROWSER: ://make_default_browser
+            VIEW_BOOKMARKS: ://urls_bookmarks
+            VIEW_COLLECTIONS: ://home_collections
+            VIEW_HISTORY: ://urls_history
+            VIEW_HOMESCREEN: ://home
+            OPEN_SETTINGS_ACCESSIBILITY: ://settings_accessibility
+            OPEN_SETTINGS_ADDON_MANAGER: ://settings_addon_manager
+            OPEN_SETTINGS_DELETE_BROWSING_DATA: ://settings_delete_browsing_data
+            OPEN_SETTINGS_LOGINS: ://settings_logins
+            OPEN_SETTINGS_NOTIFICATIONS: ://settings_notifications
+            OPEN_SETTINGS_PRIVACY: ://settings_privacy
+            OPEN_SETTINGS_SEARCH_ENGINE: ://settings_search_engine
+            OPEN_SETTINGS_TRACKING_PROTECTION: ://settings_tracking_protection
+            OPEN_SETTINGS_WALLPAPERS: ://settings_wallpapers
+            OPEN_SETTINGS: ://settings
+            TURN_ON_SYNC: ://turn_on_sync
+          styles:
+            DEFAULT:
+              priority: 50
+              max-display-count: 5
+            SURVEY:
+              priority: 55
+              max-display-count: 10
+            PERSISTENT:
+              priority: 50
+              max-display-count: 20
+            WARNING:
+              priority: 60
+              max-display-count: 10
+            URGENT:
+              priority: 100
+              max-display-count: 10
+          messages:
+            default-browser:
+              text: default_browser_experiment_card_text
+              action: "MAKE_DEFAULT_BROWSER"
+              trigger: [ "I_AM_NOT_DEFAULT_BROWSER","USER_ESTABLISHED_INSTALL" ]
+              style: "PERSISTENT"
+              button-label: preferences_set_as_default_browser
+
+      - channel: developer
+        value:
+          styles:
+            DEFAULT:
+              priority: 50
+              max-display-count: 100
+            EXPIRES_QUICKLY:
+              priority: 100
+              max-display-count: 1
+          notification-config:
+            polling-interval: 180 # 3 minutes
+
+objects:
+  MessageData:
+    description: >
+      An object to describe a message. It uses human
+      readable strings to describe the triggers, action and
+      style of the message as well as the text of the message
+      and call to action.
+    fields:
+      action:
+        type: Text
+        description: >
+          A URL of a page or a deeplink.
+          This may have substitution variables in.
+        # This should never be defaulted.
+        default: empty_string
+      title:
+        type: Option<Text>
+        description: "The title text displayed to the user"
+        default: null
+      text:
+        type: Text
+        description: "The message text displayed to the user"
+        # This should never be defaulted.
+        default: empty_string
+      is-control:
+        type: Boolean
+        description: "Indicates if this message is the control message, if true shouldn't be displayed"
+        default: false
+      button-label:
+        type: Option<Text>
+        description: >
+          The text on the button. If no text
+          is present, the whole message is clickable.
+        default: null
+      style:
+        type: String
+        description: >
+          The style as described in a
+          `StyleData` from the styles table.
+        default: DEFAULT
+      trigger:
+        type: List<String>
+        description: >
+          A list of strings corresponding to
+          targeting expressions. The message will be
+          shown if all expressions `true`.
+        default: []
+  StyleData:
+    description: >
+      A group of properities (predominantly visual) to
+      describe the style of the message.
+    fields:
+      priority:
+        type: Int
+        description: >
+          The importance of this message.
+          0 is not very important, 100 is very important.
+        default: 50
+      max-display-count:
+        type: Int
+        description: >
+          How many sessions will this message be shown to the user
+          before it is expired.
+        default: 5
+  NotificationConfig:
+    description: Attributes controlling the global configuration of notification messages.
+    fields:
+      polling-interval:
+        type: Int
+        description: >
+          How often, in seconds, the notification message worker will wake up and check for new
+          messages.
+        default: 3600
+
+enums:
+  ControlMessageBehavior:
+    description: An enum to influence what should be displayed when a control message is selected.
+    variants:
+      show-next-message:
+        description: The next eligible message should be shown.
+      show-none:
+        description: The surface should show no message.

--- a/messaging.fml.yaml
+++ b/messaging.fml.yaml
@@ -98,6 +98,7 @@ features:
           messages:
             default-browser:
               text: default_browser_experiment_card_text
+              surface: homescreen
               action: "MAKE_DEFAULT_BROWSER"
               trigger: [ "I_AM_NOT_DEFAULT_BROWSER","USER_ESTABLISHED_INSTALL" ]
               style: "PERSISTENT"

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -9,6 +9,8 @@ channels:
   - beta
   - nightly
   - developer
+includes:
+  - ./messaging.fml.yaml
 features:
   homescreen:
     description: The homescreen that the user goes to when they press home or new tab.
@@ -73,121 +75,6 @@ features:
       - channel: developer
         value:
           enabled: true
-  messaging:
-    description: |
-      Configuration for the messaging system.
-
-      In practice this is a set of growable lookup tables for the
-      message controller to piece together.
-
-    variables:
-      message-under-experiment:
-        description: Id or prefix of the message under experiment.
-        type: Option<String>
-        default: null
-
-      messages:
-        description: A growable collection of messages
-        type: Map<String, MessageData>
-        default: {}
-
-      triggers:
-        description: >
-          A collection of out the box trigger
-          expressions. Each entry maps to a
-          valid JEXL expression.
-        type: Map<String, String>
-        default: {}
-      styles:
-        description: >
-          A map of styles to configure message
-          appearance.
-        type: Map<String, StyleData>
-        default: {}
-
-      actions:
-        type: Map<String, String>
-        description: A growable map of action URLs.
-        default: {}
-      on-control:
-        type: ControlMessageBehavior
-        description: What should be displayed when a control message is selected.
-        default: show-next-message
-      notification-config:
-        description: Configuration of the notification worker for all notification messages.
-        type: NotificationConfig
-        default: {}
-    defaults:
-      - value:
-          triggers:
-            USER_RECENTLY_INSTALLED: days_since_install < 7
-            USER_RECENTLY_UPDATED: days_since_update < 7 && days_since_install != days_since_update
-            USER_TIER_ONE_COUNTRY: ('US' in locale || 'GB' in locale || 'CA' in locale || 'DE' in locale || 'FR' in locale)
-            USER_EN_SPEAKER: "'en' in locale"
-            USER_DE_SPEAKER: "'de' in locale"
-            USER_FR_SPEAKER: "'fr' in locale"
-            DEVICE_ANDROID: os == 'Android'
-            DEVICE_IOS: os == 'iOS'
-            ALWAYS: "true"
-            NEVER: "false"
-            I_AM_DEFAULT_BROWSER: "is_default_browser"
-            I_AM_NOT_DEFAULT_BROWSER: "is_default_browser == false"
-            USER_ESTABLISHED_INSTALL: "number_of_app_launches >=4"
-          actions:
-            ENABLE_PRIVATE_BROWSING: ://enable_private_browsing
-            INSTALL_SEARCH_WIDGET: ://install_search_widget
-            MAKE_DEFAULT_BROWSER: ://make_default_browser
-            VIEW_BOOKMARKS: ://urls_bookmarks
-            VIEW_COLLECTIONS: ://home_collections
-            VIEW_HISTORY: ://urls_history
-            VIEW_HOMESCREEN: ://home
-            OPEN_SETTINGS_ACCESSIBILITY: ://settings_accessibility
-            OPEN_SETTINGS_ADDON_MANAGER: ://settings_addon_manager
-            OPEN_SETTINGS_DELETE_BROWSING_DATA: ://settings_delete_browsing_data
-            OPEN_SETTINGS_LOGINS: ://settings_logins
-            OPEN_SETTINGS_NOTIFICATIONS: ://settings_notifications
-            OPEN_SETTINGS_PRIVACY: ://settings_privacy
-            OPEN_SETTINGS_SEARCH_ENGINE: ://settings_search_engine
-            OPEN_SETTINGS_TRACKING_PROTECTION: ://settings_tracking_protection
-            OPEN_SETTINGS_WALLPAPERS: ://settings_wallpapers
-            OPEN_SETTINGS: ://settings
-            TURN_ON_SYNC: ://turn_on_sync
-          styles:
-            DEFAULT:
-              priority: 50
-              max-display-count: 5
-            SURVEY:
-              priority: 55
-              max-display-count: 10
-            PERSISTENT:
-              priority: 50
-              max-display-count: 20
-            WARNING:
-              priority: 60
-              max-display-count: 10
-            URGENT:
-              priority: 100
-              max-display-count: 10
-          messages:
-            default-browser:
-              text: default_browser_experiment_card_text
-              action: "MAKE_DEFAULT_BROWSER"
-              trigger: [ "I_AM_NOT_DEFAULT_BROWSER","USER_ESTABLISHED_INSTALL" ]
-              style: "PERSISTENT"
-              button-label: preferences_set_as_default_browser
-
-      - channel: developer
-        value:
-          styles:
-            DEFAULT:
-              priority: 50
-              max-display-count: 100
-            EXPIRES_QUICKLY:
-              priority: 100
-              max-display-count: 1
-          notification-config:
-            polling-interval: 180 # 3 minutes
-
   mr2022:
     description: Features for MR 2022.
     variables:
@@ -287,88 +174,9 @@ features:
         default: true
 
 types:
-  objects:
-    MessageData:
-      description: >
-        An object to describe a message. It uses human
-        readable strings to describe the triggers, action and
-        style of the message as well as the text of the message
-        and call to action.
-      fields:
-        action:
-          type: Text
-          description: >
-            A URL of a page or a deeplink.
-            This may have substitution variables in.
-          # This should never be defaulted.
-          default: empty_string
-        title:
-          type: Option<Text>
-          description: "The title text displayed to the user"
-          default: null
-        text:
-          type: Text
-          description: "The message text displayed to the user"
-          # This should never be defaulted.
-          default: empty_string
-        is-control:
-          type: Boolean
-          description: "Indicates if this message is the control message, if true shouldn't be displayed"
-          default: false
-        button-label:
-          type: Option<Text>
-          description: >
-            The text on the button. If no text
-            is present, the whole message is clickable.
-          default: null
-        style:
-          type: String
-          description: >
-            The style as described in a
-            `StyleData` from the styles table.
-          default: DEFAULT
-        trigger:
-          type: List<String>
-          description: >
-            A list of strings corresponding to
-            targeting expressions. The message will be
-            shown if all expressions `true`.
-          default: []
-    StyleData:
-      description: >
-        A group of properities (predominantly visual) to
-        describe the style of the message.
-      fields:
-        priority:
-          type: Int
-          description: >
-            The importance of this message.
-            0 is not very important, 100 is very important.
-          default: 50
-        max-display-count:
-          type: Int
-          description: >
-            How many sessions will this message be shown to the user
-            before it is expired.
-          default: 5
-    NotificationConfig:
-      description: Attributes controlling the global configuration of notification messages.
-      fields:
-        polling-interval:
-          type: Int
-          description: >
-            How often, in seconds, the notification message worker will wake up and check for new
-            messages.
-          default: 3600
+  objects: {}
 
   enums:
-    ControlMessageBehavior:
-      description: An enum to influence what should be displayed when a control message is selected.
-      variants:
-        show-next-message:
-          description: The next eligible message should be shown.
-        show-none:
-          description: The surface should show no message.
     HomeScreenSection:
       description: The identifiers for the sections of the homescreen.
       variants:
@@ -384,15 +192,7 @@ types:
           description: The pocket section. This should only be available in the US.
         pocket-sponsored-stories:
           description: Subsection of the Pocket homescreen section which shows sponsored stories.
-    MessageSurfaceId:
-      description: The identity of a message surface, used in the default browser experiments
-      variants:
-        app-menu-item:
-          description: An item in the default toolbar menu.
-        settings:
-          description: A setting in the settings screen.
-        homescreen-banner:
-          description: A banner in the homescreen.
+
     MR2022Section:
       description: The identifiers for the sections of the MR 2022.
       variants:


### PR DESCRIPTION
This adds a `surface` parameter to the `getMessages()` method in `NimbusMessagingStorage`.

It also takes the opportunity to refactor the `messaging` feature in the `nimbus.fml.yaml` into a separate `messaging.fml.yaml`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
