### PR TITLE
For #28262 - Refactor InactiveTabsAutoCloseDialogInteractor into InactiveTabsInteractor

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabViewHolder.kt
@@ -64,11 +64,11 @@ class InactiveTabViewHolder(
                 onHeaderClick = { interactor.onHeaderClicked(!expanded) },
                 onDeleteAllButtonClick = interactor::onDeleteAllInactiveTabsClicked,
                 onAutoCloseDismissClick = {
-                    interactor.onCloseClicked()
+                    interactor.onAutoCloseDialogCloseButtonClicked()
                     showAutoClosePrompt = !showAutoClosePrompt
                 },
                 onEnableAutoCloseClick = {
-                    interactor.onEnabledAutoCloseClicked()
+                    interactor.onEnableAutoCloseClicked()
                     showAutoClosePrompt = !showAutoClosePrompt
                     showConfirmationSnackbar()
                 },

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabsInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabsInteractor.kt
@@ -10,7 +10,7 @@ import org.mozilla.fenix.tabstray.TrayPagerAdapter
 /**
  * Interactor for all things related to inactive tabs in the tabs tray.
  */
-interface InactiveTabsInteractor : InactiveTabsAutoCloseDialogInteractor {
+interface InactiveTabsInteractor {
     /**
      * Invoked when the header is clicked.
      *
@@ -36,29 +36,25 @@ interface InactiveTabsInteractor : InactiveTabsAutoCloseDialogInteractor {
      * Invoked when the user clicks on the delete all inactive tabs button.
      */
     fun onDeleteAllInactiveTabsClicked()
-}
-
-/**
- * Interactor for the auto-close dialog in the inactive tabs section.
- */
-interface InactiveTabsAutoCloseDialogInteractor {
 
     /**
-     * Invoked when the close button is clicked.
+     * Invoked when the user clicks the close button in the auto close dialog.
      */
-    fun onCloseClicked()
+    fun onAutoCloseDialogCloseButtonClicked()
 
     /**
-     * Invoked when the dialog is clicked.
+     * Enable the auto-close feature with the "after a month" setting.
      */
-    fun onEnabledAutoCloseClicked()
+    fun onEnableAutoCloseClicked()
 }
 
 /**
  * Interactor to be called for any user interactions with the Inactive Tabs feature.
  *
- * @param controller [InactiveTabsController] todo.
- * @param browserInteractor [BrowserTrayInteractor] used to respond to interactions with specific inactive tabs.
+ * @param controller An instance of [InactiveTabsController] which will be delegated for all
+ * user interactions.
+ * @param browserInteractor [BrowserTrayInteractor] used to respond to interactions with specific
+ * inactive tabs.
  */
 class DefaultInactiveTabsInteractor(
     private val controller: InactiveTabsController,
@@ -73,16 +69,16 @@ class DefaultInactiveTabsInteractor(
     }
 
     /**
-     * See [InactiveTabsAutoCloseDialogInteractor.onCloseClicked].
+     * See [InactiveTabsInteractor.onAutoCloseDialogCloseButtonClicked].
      */
-    override fun onCloseClicked() {
+    override fun onAutoCloseDialogCloseButtonClicked() {
         controller.dismissAutoCloseDialog()
     }
 
     /**
-     * See [InactiveTabsAutoCloseDialogInteractor.onEnabledAutoCloseClicked].
+     * See [InactiveTabsInteractor.onEnableAutoCloseClicked].
      */
-    override fun onEnabledAutoCloseClicked() {
+    override fun onEnableAutoCloseClicked() {
         controller.enableInactiveTabsAutoClose()
     }
 

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/DefaultInactiveTabsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/DefaultInactiveTabsInteractorTest.kt
@@ -25,14 +25,14 @@ class DefaultInactiveTabsInteractorTest {
 
     @Test
     fun `WHEN the inactive tabs auto close dialog's close button is clicked THEN dismiss the dialog`() {
-        createInteractor().onCloseClicked()
+        createInteractor().onAutoCloseDialogCloseButtonClicked()
 
         verify { controller.dismissAutoCloseDialog() }
     }
 
     @Test
     fun `WHEN the enable inactive tabs auto close button is clicked THEN turn on the auto close feature`() {
-        createInteractor().onEnabledAutoCloseClicked()
+        createInteractor().onEnableAutoCloseClicked()
 
         verify { controller.enableInactiveTabsAutoClose() }
     }


### PR DESCRIPTION
PR 2 of 9 for https://github.com/mozilla-mobile/fenix/issues/25722

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #28262