### PR TITLE
Bug28280 - Add telemetry for form data failures

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -540,6 +540,22 @@ events:
     metadata:
       tags:
         - Sharing
+  form_data_failure:
+    type: event
+    description: |
+      Form data retrieval from a tab failed.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/28280
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/28280#issuecomment-1376040252
+    notification_emails:
+      - android-probes@mozilla.com
+    data_sensitivity:
+      - technical
+    expires: 121
+    metadata:
+      tags:
+        - Sharing
 
 onboarding:
   syn_cfr_shown:

--- a/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryMiddleware.kt
@@ -19,6 +19,7 @@ import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
 import mozilla.components.support.base.android.Clock
 import mozilla.components.support.base.log.logger.Logger
+import mozilla.telemetry.glean.private.NoExtras
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.Metrics
 import org.mozilla.fenix.components.metrics.MetricController
@@ -58,6 +59,9 @@ class TelemetryMiddleware(
             is EngineAction.KillEngineSessionAction -> {
                 val tab = context.state.findTabOrCustomTab(action.tabId)
                 onEngineSessionKilled(context.state, tab)
+            }
+            is ContentAction.CheckForFormDataExceptionAction -> {
+                Events.formDataFailure.record(NoExtras())
             }
             else -> {
                 // no-op

--- a/app/src/test/java/org/mozilla/fenix/telemetry/TelemetryMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/telemetry/TelemetryMiddlewareTest.kt
@@ -350,6 +350,17 @@ class TelemetryMiddlewareTest {
         assertNull(EngineMetrics.killForegroundAge.testGetValue())
         assertEquals(600_000_000, EngineMetrics.killBackgroundAge.testGetValue()!!.sum)
     }
+
+    @Test
+    fun `GIVEN the request to check for form data WHEN it fails THEN telemetry is sent`() {
+        assertNull(Events.formDataFailure.testGetValue())
+
+        store.dispatch(
+            ContentAction.CheckForFormDataExceptionAction("1", RuntimeException("session form data request failed")),
+        ).joinBlocking()
+
+        assertNotNull(Events.formDataFailure.testGetValue())
+    }
 }
 
 internal class FakeClock : Clock.Delegate {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
