### PR TITLE
Closes 1807531: Honor private_browsing_mode value from external intents

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -58,7 +58,12 @@ class IntentReceiverActivity : Activity() {
 
     fun processIntent(intent: Intent) {
         // Call process for side effects, short on the first that returns true
-        val private = settings().openLinksInAPrivateTab
+
+        var private = settings().openLinksInAPrivateTab
+        if (!private) {
+            // if PRIVATE_BROWSING_MODE is already set to true, honor that
+            private = intent.getBooleanExtra(PRIVATE_BROWSING_MODE, false)
+        }
         intent.putExtra(PRIVATE_BROWSING_MODE, private)
         if (private) {
             Events.openedLink.record(Events.OpenedLinkExtra("PRIVATE"))


### PR DESCRIPTION
Change IntentReceiverActivity so that if the incoming intent has the `private_browsing_mode` extra set to true, it overrides the openLinksInAPrivateTab setting. This allows external apps to set this flag for sites they want opened in a private app explicitly.

External apps cannot force the link to open in a non-private tab if openLinksInAPrivateTab is enabled, in that case the extra will be ignored.

This is similar to an old fennec feature ( https://bugzilla.mozilla.org/show_bug.cgi?id=1347583 ), however I used the "private_browsing_mode" extra name since it already appears in the code, instead of the "private_tab" extra that fennec used.

Bugzilla bug is 1807531, GitHub bug is #26158



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes a unit test
- [x] **Screenshots**: This PR does not change UI so does not need screenshots
- [x] **Accessibility**: This PR does not change UI so does not need accessibility changes

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #26158