### PR TITLE
Close #28469: Add notification permission prompt onboarding strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -274,6 +274,16 @@
     <!-- Content description (not visible, for screen readers etc.): Close button for the home onboarding dialog -->
     <string name="onboarding_home_content_description_close_button">Close</string>
 
+    <!-- Notification pre-permission dialog -->
+    <!-- Enable notification pre permission dialog title -->
+    <string name="onboarding_home_enable_notifications_title" tools:ignore="UnusedResources">Notifications help you do more with Firefox</string>
+    <!-- Enable notification pre permission dialog description with rationale -->
+    <string name="onboarding_home_enable_notifications_description" tools:ignore="UnusedResources">Sync your tabs between devices, manage downloads, get tips about making the most of Firefox’s privacy protection, and more.</string>
+    <!-- Text for the button to enable app notifications on the device -->
+    <string name="onboarding_home_enable_notifications_positive_button" tools:ignore="UnusedResources">Enable notifications</string>
+    <!-- Text for the button to not enable app notifications on the device and dismiss the dialog -->
+    <string name="onboarding_home_enable_notifications_negative_button" tools:ignore="UnusedResources">No thanks</string>
+
     <!-- Search Widget -->
     <!-- Content description for searching with a widget. The first parameter is the name of the application.-->
     <string name="search_widget_content_description_2">Open a new %1$s tab</string>


### PR DESCRIPTION
This is to add the strings needed for https://bugzilla.mozilla.org/show_bug.cgi?id=1808874.  Following the design [here](https://www.figma.com/file/d7l1iGabQYqnLcnQbHDGzM/Wallpaper-2.0-%2B-Onboarding-v106?node-id=8924%3A220946&t=hlpKOueTm655Emde-0)

![NotificationPrompt](https://user-images.githubusercontent.com/6579541/211400256-c34b34fa-ed3d-4732-bc52-adc824505901.jpg)

 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #28469