### PR TITLE
Update DownloadFileTypesTest.kt

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadFileTypesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadFileTypesTest.kt
@@ -33,7 +33,7 @@ class DownloadFileTypesTest(fileName: String) {
         @JvmStatic
         @Parameterized.Parameters
         fun downloadList() = listOf(
-            "washington.pdf",
+            "smallZip.zip",
             "MyDocument.docx",
             "audioSample.mp3",
             "textfile.txt",


### PR DESCRIPTION
Swapping out expected PDF download in anticipation for enabling `PDF.js` on mobile https://bugzilla.mozilla.org/show_bug.cgi?id=1803959