### PR TITLE
Revert "Closes #28417: Add nimbus flags for pre permission prompt"

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -74,14 +74,6 @@ nimbus-validation:
     settings-title:
       type: string
       description: The title of displayed in the Settings screen and app menu.
-pre-permission-notification-prompt:
-  description: A feature that shows the pre-permission notification prompt.
-  hasExposure: true
-  exposureDescription: ""
-  variables:
-    enabled:
-      type: boolean
-      description: "if true, the pre-permission notification prompt is shown to the user."
 re-engagement-notification:
   description: A feature that shows the re-enagement notification if the user is inactive.
   hasExposure: true

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -278,14 +278,6 @@ features:
         type: Boolean
         default: true
 
-  pre-permission-notification-prompt:
-    description: A feature that shows the pre-permission notification prompt.
-    variables:
-      enabled:
-        description: if true, the pre-permission notification prompt is shown to the user.
-        type: Boolean
-        default: true
-
 types:
   objects:
     MessageData:


### PR DESCRIPTION
Confirmed with Product that notification prompt doesn't not need a Nimbus experiment.
Reverts mozilla-mobile/fenix#28418