### PR TITLE
Bug 1809507 - Use base domain on the cookie banner handling panel.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/CookieBannerPanelDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/CookieBannerPanelDialogFragment.kt
@@ -85,6 +85,7 @@ class CookieBannerPanelDialogFragment : FenixDialogFragment() {
 
         cookieBannersView = CookieBannerHandlingDetailsView(
             context = requireContext(),
+            ioScope = viewLifecycleOwner.lifecycleScope + Dispatchers.IO,
             container = binding.cookieBannerDetailsInfoLayout,
             publicSuffixList = requireComponents.publicSuffixList,
             interactor = DefaultCookieBannerDetailsInteractor(controller),


### PR DESCRIPTION
**Now**

![image](https://user-images.githubusercontent.com/773158/211661830-792bdb25-6101-44eb-a7ed-eac0816318f7.png)

**Before** 

![image](https://user-images.githubusercontent.com/773158/211678296-a454f3eb-4c3d-4ffe-a64b-a0c289659ca0.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
