### PR TITLE
Revert "Revert "Closes #28417: Add nimbus flags for pre permission prompt""

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -74,6 +74,14 @@ nimbus-validation:
     settings-title:
       type: string
       description: The title of displayed in the Settings screen and app menu.
+pre-permission-notification-prompt:
+  description: A feature that shows the pre-permission notification prompt.
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    enabled:
+      type: boolean
+      description: "if true, the pre-permission notification prompt is shown to the user."
 re-engagement-notification:
   description: A feature that shows the re-enagement notification if the user is inactive.
   hasExposure: true

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -278,6 +278,14 @@ features:
         type: Boolean
         default: true
 
+  pre-permission-notification-prompt:
+    description: A feature that shows the pre-permission notification prompt.
+    variables:
+      enabled:
+        description: if true, the pre-permission notification prompt is shown to the user.
+        type: Boolean
+        default: true
+
 types:
   objects:
     MessageData:


### PR DESCRIPTION
This is to put back the Nimbus flag for the pre-permission prompt.

Reverts mozilla-mobile/fenix#28484