### PR TITLE
Bug 1806798 - Better handle longer filenames in download finished dialog. #527

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/downloads/DynamicDownloadDialog.kt
+++ b/app/src/main/java/org/mozilla/fenix/downloads/DynamicDownloadDialog.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.downloads
 
 import android.content.Context
+import android.text.method.ScrollingMovementMethod
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.MimeTypeMap
@@ -112,6 +113,7 @@ class DynamicDownloadDialog(
         }
 
         binding.downloadDialogFilename.text = downloadState.fileName
+        binding.downloadDialogFilename.movementMethod = ScrollingMovementMethod()
     }
 
     fun show() {

--- a/app/src/main/res/layout/download_dialog_layout.xml
+++ b/app/src/main/res/layout/download_dialog_layout.xml
@@ -57,6 +57,7 @@
         android:id="@+id/download_dialog_filename"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:maxHeight="160dp"
         android:layout_marginStart="3dp"
         android:layout_marginEnd="16dp"
         android:layout_marginTop="8dp"
@@ -64,10 +65,11 @@
         android:paddingTop="4dp"
         android:paddingEnd="5dp"
         android:textColor="?attr/textPrimary"
+        android:scrollbars="vertical"
         app:layout_constraintStart_toEndOf="@id/download_dialog_icon"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/download_dialog_title"
-        tools:text="l38ID7Xze57vCac8C9oD7Z2LXzBw00HDiw7XR6ZDu5G5O8uyODAVEOTS2PrZt8OoBM77CmaFyrdGxUODuEWwpfzwnTsTTRcGDsr6Cez4Q7DK0Kr0KJIRVAFbV4czwMeiI25FIml6QCMvQR8nBZHe1oUPQn23BplLC4c3iXGvuEBGEhyU81UpqqTSwU5tfxZ7mBOYcQUqYNG0A7ixekg9awVeq8PncVdCZKLA0hXgJEW4.svg" />
+        tools:text="@tools:sample/lorem/random" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/download_dialog_action_button"


### PR DESCRIPTION
Also add a max height for the file name, so the action button is always visible.

<img src = https://user-images.githubusercontent.com/48995920/212347109-63bdc92c-5dc4-415b-a93a-0611200ec845.png width = 45%>


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
