### PR TITLE
Closes EXP-2986 - Add adjust params to custom attributes for messaging display triggers

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
+++ b/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
@@ -9,12 +9,12 @@ import mozilla.components.service.nimbus.NimbusApi
 import mozilla.components.service.nimbus.NimbusAppInfo
 import mozilla.components.service.nimbus.NimbusBuilder
 import mozilla.components.support.base.log.logger.Logger
-import org.json.JSONObject
 import org.mozilla.experiments.nimbus.internal.NimbusException
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.gleanplumb.CustomAttributeProvider
 import org.mozilla.fenix.nimbus.FxNimbus
 
 /**
@@ -29,19 +29,12 @@ private const val TIME_OUT_LOADING_EXPERIMENT_FROM_DISK_MS = 200L
  * Create the Nimbus singleton object for the Fenix app.
  */
 fun createNimbus(context: Context, urlString: String?): NimbusApi {
+    // These values can be used in the JEXL expressions when targeting experiments.
+    val customTargetingAttributes = CustomAttributeProvider.getCustomTargetingAttributes(context)
+
     val isAppFirstRun = context.settings().isFirstNimbusRun
     if (isAppFirstRun) {
         context.settings().isFirstNimbusRun = false
-    }
-
-    // These values can be used in the JEXL expressions when targeting experiments.
-    val customTargetingAttributes = JSONObject().apply {
-        // By convention, we should use snake case.
-        put("is_first_run", isAppFirstRun)
-
-        // This camelCase attribute is a boolean value represented as a string.
-        // This is left for backwards compatibility.
-        put("isFirstRun", isAppFirstRun.toString())
     }
 
     // The name "fenix" here corresponds to the app_name defined for the family of apps

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/CustomAttributeProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/CustomAttributeProvider.kt
@@ -25,11 +25,17 @@ object CustomAttributeProvider {
      */
     fun getCustomAttributes(context: Context): JSONObject {
         val now = Calendar.getInstance()
+        val settings = context.settings()
         return JSONObject(
             mapOf(
-                "is_default_browser_string" to BrowsersCache.all(context).isDefaultBrowser.toString(),
+                "is_default_browser" to BrowsersCache.all(context).isDefaultBrowser,
                 "date_string" to formatter.format(now.time),
-                "number_of_app_launches" to context.settings().numberOfAppLaunches,
+                "number_of_app_launches" to settings.numberOfAppLaunches,
+
+                "adjust_campaign" to settings.adjustCampaignId,
+                "adjust_network" to settings.adjustNetwork,
+                "adjust_ad_group" to settings.adjustAdGroup,
+                "adjust_creative" to settings.adjustCreative,
             ),
         )
     }

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/CustomAttributeProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/CustomAttributeProvider.kt
@@ -5,7 +5,9 @@
 package org.mozilla.fenix.gleanplumb
 
 import android.content.Context
+import androidx.core.app.NotificationManagerCompat
 import org.json.JSONObject
+import org.mozilla.fenix.ext.areNotificationsEnabledSafe
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.utils.BrowsersCache
 import java.text.SimpleDateFormat
@@ -20,8 +22,31 @@ object CustomAttributeProvider {
     private val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
 
     /**
+     * Return a [JSONObject] of custom attributes used for experiment targeting.
+     *
+     * These are only evaluated right at the beginning of start up, so any first run experiments needing
+     * targeting attributes which aren't set until after startup e.g. are_notifications_enabled
+     * will unlikely to targeted as expected.
+     */
+    fun getCustomTargetingAttributes(context: Context): JSONObject {
+        val isFirstRun = context.settings().isFirstNimbusRun
+        return JSONObject(
+            mapOf(
+                // By convention, we should use snake case.
+                "is_first_run" to isFirstRun,
+
+                // This camelCase attribute is a boolean value represented as a string.
+                // This is left for backwards compatibility.
+                "isFirstRun" to isFirstRun.toString(),
+            ),
+        )
+    }
+
+    /**
      * Returns a [JSONObject] that contains all the custom attributes, evaluated when the function
      * was called.
+     *
+     * This is used to drive display triggers of messages.
      */
     fun getCustomAttributes(context: Context): JSONObject {
         val now = Calendar.getInstance()
@@ -36,6 +61,8 @@ object CustomAttributeProvider {
                 "adjust_network" to settings.adjustNetwork,
                 "adjust_ad_group" to settings.adjustAdGroup,
                 "adjust_creative" to settings.adjustCreative,
+
+                "are_notifications_enabled" to NotificationManagerCompat.from(context).areNotificationsEnabledSafe(),
             ),
         )
     }

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -130,8 +130,8 @@ features:
             DEVICE_IOS: os == 'iOS'
             ALWAYS: "true"
             NEVER: "false"
-            I_AM_DEFAULT_BROWSER: "is_default_browser_string == 'true'"
-            I_AM_NOT_DEFAULT_BROWSER: "is_default_browser_string == 'false'"
+            I_AM_DEFAULT_BROWSER: "is_default_browser"
+            I_AM_NOT_DEFAULT_BROWSER: "is_default_browser == false"
             USER_ESTABLISHED_INSTALL: "number_of_app_launches >=4"
           actions:
             ENABLE_PRIVATE_BROWSING: ://enable_private_browsing


### PR DESCRIPTION
Fixes [EXP-2986](https://mozilla-hub.atlassian.net/browse/EXP-2986).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
