### PR TITLE
For #28498: Fixed empty list text alignment in Tabs tray, history and downloads

### DIFF
--- a/app/src/main/res/layout/component_downloads.xml
+++ b/app/src/main/res/layout/component_downloads.xml
@@ -22,7 +22,7 @@
 
     <TextView
         android:id="@+id/download_empty_view"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:gravity="center"
         android:text="@string/download_empty_message_1"

--- a/app/src/main/res/layout/component_history.xml
+++ b/app/src/main/res/layout/component_history.xml
@@ -36,7 +36,7 @@
 
     <TextView
         android:id="@+id/history_empty_view"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:gravity="center"
         android:text="@string/history_empty_message"

--- a/app/src/main/res/layout/normal_browser_tray_list.xml
+++ b/app/src/main/res/layout/normal_browser_tray_list.xml
@@ -13,11 +13,11 @@
 
     <TextView
         android:id="@+id/tab_tray_empty_view"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:focusable="true"
         android:focusableInTouchMode="true"
-        android:gravity="center_horizontal"
+        android:layout_gravity="center_horizontal"
         android:paddingTop="80dp"
         android:text="@string/no_open_tabs_description"
         android:textColor="?attr/textSecondary"

--- a/app/src/main/res/layout/private_browser_tray_list.xml
+++ b/app/src/main/res/layout/private_browser_tray_list.xml
@@ -13,11 +13,11 @@
 
     <TextView
         android:id="@+id/tab_tray_empty_view"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:focusable="true"
         android:focusableInTouchMode="true"
-        android:gravity="center_horizontal"
+        android:layout_gravity="center_horizontal"
         android:paddingTop="80dp"
         android:text="@string/no_open_tabs_description"
         android:textColor="?attr/textSecondary"


### PR DESCRIPTION
The PR fixes the text alignment of empty tabs tray, history and downloads messages.

### Steps to reproduce

1. Open the tabs tray
2. Check empty tabs tray message
3. Tap the private open tabs
4. Check empty private tabs tray message
5. Open "History" from the home screen ⋮ button
6. Check empty history list message
7. Open "Downloads" from the home screen ⋮ button
8. Check empty Downloads list message

### Issue video
https://www.loom.com/share/ec33cb283a324f60a78b6da4441172b4

### Demo video after fix
https://www.loom.com/share/04a3b526e7ad440f8efa01d76da029e5

### Pull Request checklist
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots:** This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

**QA**
- [x] QA Needed
### To download an APK when reviewing a PR (after all CI tasks finished running):

1. Click on Checks at the top of the PR page.
2. Click on the firefoxci-taskcluster group on the left to expand all tasks.
3. Click on the build-debug task.
4. Click on View task in Taskcluster in the new DETAILS section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #28498