### PR TITLE
Bug 1810114 - Move marketingNotificationAllowed metric to FenixApplication

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -61,6 +61,7 @@ import mozilla.components.support.webextensions.WebExtensionSupport
 import org.mozilla.fenix.GleanMetrics.Addons
 import org.mozilla.fenix.GleanMetrics.AndroidAutofill
 import org.mozilla.fenix.GleanMetrics.CustomizeHome
+import org.mozilla.fenix.GleanMetrics.Events.marketingNotificationAllowed
 import org.mozilla.fenix.GleanMetrics.GleanBuildInfo
 import org.mozilla.fenix.GleanMetrics.Metrics
 import org.mozilla.fenix.GleanMetrics.PerfStartup
@@ -73,13 +74,16 @@ import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.components.metrics.MetricServiceType
 import org.mozilla.fenix.components.metrics.MozillaProductDetector
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
+import org.mozilla.fenix.ext.areNotificationsEnabledSafe
 import org.mozilla.fenix.ext.containsQueryParameters
 import org.mozilla.fenix.ext.getCustomGleanServerUrlIfAvailable
 import org.mozilla.fenix.ext.isCustomEngine
 import org.mozilla.fenix.ext.isKnownSearchDomain
+import org.mozilla.fenix.ext.isNotificationChannelEnabled
 import org.mozilla.fenix.ext.setCustomEndpointIfAvailable
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.nimbus.FxNimbus
+import org.mozilla.fenix.onboarding.MARKETING_CHANNEL_ID
 import org.mozilla.fenix.perf.MarkersActivityLifecycleCallbacks
 import org.mozilla.fenix.perf.ProfilerMarkerFactProcessor
 import org.mozilla.fenix.perf.StartupTimeline
@@ -723,14 +727,11 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
             defaultWallpaper.set(isDefaultTheCurrentWallpaper)
 
-            @Suppress("TooGenericExceptionCaught")
-            try {
-                notificationsAllowed.set(
-                    NotificationManagerCompat.from(applicationContext).areNotificationsEnabled(),
-                )
-            } catch (e: Exception) {
-                Logger.warn("Failed to check if notifications are enabled", e)
-            }
+            val notificationManagerCompat = NotificationManagerCompat.from(applicationContext)
+            notificationsAllowed.set(notificationManagerCompat.areNotificationsEnabledSafe())
+            marketingNotificationAllowed.set(
+                notificationManagerCompat.isNotificationChannelEnabled(MARKETING_CHANNEL_ID),
+            )
         }
 
         with(AndroidAutofill) {

--- a/app/src/main/java/org/mozilla/fenix/ext/NotificationManagerCompat.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/NotificationManagerCompat.kt
@@ -4,6 +4,8 @@
 
 package org.mozilla.fenix.ext
 
+import android.os.Build
+import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationManagerCompat
 
 /**
@@ -16,5 +18,43 @@ fun NotificationManagerCompat.areNotificationsEnabledSafe(): Boolean {
         areNotificationsEnabled()
     } catch (e: Exception) {
         false
+    }
+}
+
+/**
+ * If the channel does not exist or is null, this returns false.
+ * If the channel exists with importance more than [NotificationManagerCompat.IMPORTANCE_NONE] and
+ * notifications are enabled for the app, this returns true.
+ * On <= SDK 26, this checks if notifications are enabled for the app.
+ *
+ * @param channelId the id of the notification channel to check.
+ * @return true if the channel is enabled, false otherwise.
+ */
+fun NotificationManagerCompat.isNotificationChannelEnabled(channelId: String): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val channel = getNotificationChannelSafe(channelId)
+        if (channel == null) {
+            false
+        } else {
+            areNotificationsEnabledSafe() && channel.importance != NotificationManagerCompat.IMPORTANCE_NONE
+        }
+    } else {
+        areNotificationsEnabledSafe()
+    }
+}
+
+/**
+ * Returns the notification channel with the given [channelId], or null if the channel does not
+ * exist, catches any exception that was thrown by
+ * [NotificationManagerCompat.getNotificationChannelCompat] and returns null.
+ *
+ * @param channelId the id of the notification channel to check.
+ */
+@Suppress("TooGenericExceptionCaught")
+private fun NotificationManagerCompat.getNotificationChannelSafe(channelId: String): NotificationChannelCompat? {
+    return try {
+        getNotificationChannelCompat(channelId)
+    } catch (e: Exception) {
+        null
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/onboarding/MarketingNotificationHelper.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/MarketingNotificationHelper.kt
@@ -8,14 +8,11 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
-import androidx.core.app.NotificationManagerCompat
-import org.mozilla.fenix.GleanMetrics.Events.marketingNotificationAllowed
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.areNotificationsEnabledSafe
 
 // Channel ID was not updated when it was renamed to marketing.  Thus, we'll have to continue
 // to use this ID as the marketing channel ID
-private const val MARKETING_CHANNEL_ID = "org.mozilla.fenix.default.browser.channel"
+const val MARKETING_CHANNEL_ID = "org.mozilla.fenix.default.browser.channel"
 
 // For notification that uses the marketing notification channel, IDs should be unique.
 const val DEFAULT_BROWSER_NOTIFICATION_ID = 1
@@ -27,7 +24,6 @@ const val RE_ENGAGEMENT_NOTIFICATION_ID = 2
  * Returns the channel id to be used for notifications.
  */
 fun ensureMarketingChannelExists(context: Context): String {
-    var channelEnabled = true
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         val notificationManager: NotificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -44,13 +40,7 @@ fun ensureMarketingChannelExists(context: Context): String {
 
             notificationManager.createNotificationChannel(channel)
         }
-
-        channelEnabled = channel.importance != NotificationManager.IMPORTANCE_NONE
     }
-
-    val notificationsEnabled = NotificationManagerCompat.from(context).areNotificationsEnabledSafe()
-
-    marketingNotificationAllowed.set(notificationsEnabled && channelEnabled)
 
     return MARKETING_CHANNEL_ID
 }

--- a/app/src/test/java/org/mozilla/fenix/ext/NotificationManagerCompatTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/NotificationManagerCompatTest.kt
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ext
+
+import android.os.Build
+import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationManagerCompat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.robolectric.util.ReflectionHelpers
+
+@RunWith(FenixRobolectricTestRunner::class)
+class NotificationManagerCompatTest {
+
+    private lateinit var tested: NotificationManagerCompat
+
+    @Before
+    fun setup() {
+        tested = mockk(relaxed = true)
+
+        mockkStatic("org.mozilla.fenix.ext.NotificationManagerCompatKt")
+    }
+
+    @Test
+    fun `WHEN areNotificationsEnabled throws an exception THEN areNotificationsEnabledSafe returns false`() {
+        every { tested.areNotificationsEnabled() } throws RuntimeException()
+
+        assertFalse(tested.areNotificationsEnabledSafe())
+    }
+
+    @Test
+    fun `WHEN areNotificationsEnabled returns false THEN areNotificationsEnabledSafe returns false`() {
+        every { tested.areNotificationsEnabled() } returns false
+
+        assertFalse(tested.areNotificationsEnabledSafe())
+    }
+
+    @Test
+    fun `WHEN areNotificationsEnabled returns true THEN areNotificationsEnabledSafe returns true`() {
+        every { tested.areNotificationsEnabled() } returns true
+
+        assertTrue(tested.areNotificationsEnabledSafe())
+    }
+
+    @Test
+    fun `WHEN getNotificationChannelCompat returns a channel with IMPORTANCE_DEFAULT and areNotificationsEnabled returns true THEN isNotificationChannelEnabled returns true`() {
+        val testChannel = "test-channel"
+        val notificationChannelCompat =
+            NotificationChannelCompat.Builder(
+                testChannel,
+                NotificationManagerCompat.IMPORTANCE_DEFAULT,
+            ).build()
+
+        every { tested.getNotificationChannelCompat(testChannel) } returns notificationChannelCompat
+        every { tested.areNotificationsEnabled() } returns true
+
+        assertTrue(tested.isNotificationChannelEnabled(testChannel))
+    }
+
+    @Test
+    fun `WHEN getNotificationChannelCompat returns a channel with IMPORTANCE_NONE and areNotificationsEnabled returns true THEN isNotificationChannelEnabled returns false`() {
+        val testChannel = "test-channel"
+        val notificationChannelCompat =
+            NotificationChannelCompat.Builder(
+                testChannel,
+                NotificationManagerCompat.IMPORTANCE_NONE,
+            ).build()
+
+        every { tested.getNotificationChannelCompat(testChannel) } returns notificationChannelCompat
+        every { tested.areNotificationsEnabled() } returns true
+
+        assertFalse(tested.isNotificationChannelEnabled(testChannel))
+    }
+
+    @Test
+    fun `WHEN getNotificationChannelCompat returns a channel and areNotificationsEnabled returns false THEN isNotificationChannelEnabled returns false`() {
+        val testChannel = "test-channel"
+        val notificationChannelCompat =
+            NotificationChannelCompat.Builder(
+                testChannel,
+                NotificationManagerCompat.IMPORTANCE_DEFAULT,
+            ).build()
+
+        every { tested.getNotificationChannelCompat(testChannel) } returns notificationChannelCompat
+        every { tested.areNotificationsEnabled() } returns false
+
+        assertFalse(tested.isNotificationChannelEnabled(testChannel))
+    }
+
+    @Test
+    fun `WHEN getNotificationChannelCompat returns null THEN isNotificationChannelEnabled returns false`() {
+        val testChannel = "test-channel"
+
+        every { tested.getNotificationChannelCompat(testChannel) } returns null
+        every { tested.areNotificationsEnabled() } returns true
+
+        assertFalse(tested.isNotificationChannelEnabled(testChannel))
+    }
+
+    @Test
+    fun `WHEN sdk less than 26 and areNotificationsEnabled returns true THEN isNotificationChannelEnabled returns true`() {
+        val testChannel = "test-channel"
+
+        ReflectionHelpers.setStaticField(Build.VERSION::class.java, "SDK_INT", 25)
+
+        every { tested.areNotificationsEnabled() } returns true
+
+        assertTrue(tested.isNotificationChannelEnabled(testChannel))
+    }
+}


### PR DESCRIPTION
– Now that [Notification pre permission prompt](https://bugzilla.mozilla.org/show_bug.cgi?id=1808874) is merged,
this moves `marketingNotificationAllowed`metric as that was called from `ensureMarketingChannelExisits` which is now behind an experiment, so now we get this metric for all app sessions.
– Extract common helper functions to `NotificationManagerCompat` and add tests.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
