### PR TITLE
Bug 1810565 - Part 1: New logins related UI tests and other refactoring work

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
@@ -117,7 +117,7 @@ class CustomTabsTest {
         }.openSavedLogins {
             verifySecurityPromptForLogins()
             tapSetupLater()
-            verifySavedLoginFromPrompt("mozilla")
+            verifySavedLoginsSectionUsername("mozilla")
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
@@ -16,6 +16,7 @@ import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper
+import org.mozilla.fenix.helpers.TestHelper.exitMenu
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
@@ -68,7 +69,7 @@ class LoginsTest {
             verifySecurityPromptForLogins()
             tapSetupLater()
             // Verify that the login appears correctly
-            verifySavedLoginFromPrompt("test@example.com")
+            verifySavedLoginsSectionUsername("test@example.com")
         }
     }
 
@@ -146,7 +147,7 @@ class LoginsTest {
             verifySecurityPromptForLogins()
             tapSetupLater()
             // Verify that the login appears correctly
-            verifySavedLoginFromPrompt("test@example.com")
+            verifySavedLoginsSectionUsername("test@example.com")
             viewSavedLoginDetails("test@example.com")
             revealPassword()
             verifyPasswordSaved("test") // failing here locally
@@ -156,7 +157,7 @@ class LoginsTest {
     @SmokeTest
     @Test
     fun verifyMultipleLoginsSelectionsTest() {
-        val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
+        val loginPage = "https://mozilla-mobile.github.io/testapp/v2.0/loginForm.html"
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loginPage.toUri()) {
@@ -169,7 +170,167 @@ class LoginsTest {
             verifySuggestedUserName("firefox")
             verifySuggestedUserName("mozilla")
             clickLoginSuggestion("mozilla")
-            verifyPrefilledLoginCredentials("mozilla")
+            clickShowPasswordButton()
+            verifyPrefilledLoginCredentials("mozilla", "firefox")
+        }
+    }
+
+    @Test
+    fun verifyEditLoginsViewTest() {
+        val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
+        val originWebsite = "mozilla-mobile.github.io"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(loginPage.toUri()) {
+            fillAndSubmitLoginCredentials("mozilla", "firefox")
+            saveLoginFromPrompt("Save")
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openLoginsAndPasswordSubMenu {
+        }.openSavedLogins {
+            tapSetupLater()
+            viewSavedLoginDetails(originWebsite)
+            clickThreeDotButton(activityTestRule)
+            clickEditLoginButton()
+            setNewPassword("fenix")
+            saveEditedLogin()
+            revealPassword()
+            verifyPasswordSaved("fenix")
+        }
+    }
+
+    @Test
+    fun verifyEditedLoginsAreSavedTest() {
+        val loginPage = "https://mozilla-mobile.github.io/testapp/v2.0/loginForm.html"
+        val originWebsite = "mozilla-mobile.github.io"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(loginPage.toUri()) {
+            fillAndSubmitLoginCredentials("mozilla", "firefox")
+            saveLoginFromPrompt("Save")
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openLoginsAndPasswordSubMenu {
+        }.openSavedLogins {
+            tapSetupLater()
+            viewSavedLoginDetails(originWebsite)
+            clickThreeDotButton(activityTestRule)
+            clickEditLoginButton()
+            setNewUserName("android")
+            setNewPassword("fenix")
+            saveEditedLogin()
+        }
+
+        exitMenu()
+
+        browserScreen {
+        }.openThreeDotMenu {
+        }.refreshPage {
+            waitForPageToLoad()
+            clickShowPasswordButton()
+            verifyPrefilledLoginCredentials("android", "fenix")
+        }
+    }
+
+    @Test
+    fun verifyLoginWithNoUserNameCanBeSavedTest() {
+        val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
+        val originWebsite = "mozilla-mobile.github.io"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(loginPage.toUri()) {
+            fillAndSubmitLoginCredentials("mozilla", "firefox")
+            saveLoginFromPrompt("Save")
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openLoginsAndPasswordSubMenu {
+        }.openSavedLogins {
+            tapSetupLater()
+            viewSavedLoginDetails(originWebsite)
+            clickThreeDotButton(activityTestRule)
+            clickEditLoginButton()
+            clickClearUserNameButton()
+            saveEditedLogin()
+        }
+    }
+
+    @Test
+    fun verifyLoginWithoutPasswordCanNotBeSavedTest() {
+        val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
+        val originWebsite = "mozilla-mobile.github.io"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(loginPage.toUri()) {
+            fillAndSubmitLoginCredentials("mozilla", "firefox")
+            saveLoginFromPrompt("Save")
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openLoginsAndPasswordSubMenu {
+        }.openSavedLogins {
+            tapSetupLater()
+            viewSavedLoginDetails(originWebsite)
+            clickThreeDotButton(activityTestRule)
+            clickEditLoginButton()
+            clickClearPasswordButton()
+            verifyPasswordRequiredErrorMessage()
+            saveEditedLogin()
+            revealPassword()
+            verifyPasswordSaved("firefox")
+        }
+    }
+
+    @Test
+    fun verifyEditModeDismissalDoesNotSaveLoginCredentialsTest() {
+        val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
+        val originWebsite = "mozilla-mobile.github.io"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(loginPage.toUri()) {
+            fillAndSubmitLoginCredentials("mozilla", "firefox")
+            saveLoginFromPrompt("Save")
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openLoginsAndPasswordSubMenu {
+        }.openSavedLogins {
+            tapSetupLater()
+            viewSavedLoginDetails(originWebsite)
+            clickThreeDotButton(activityTestRule)
+            clickEditLoginButton()
+            setNewUserName("android")
+            setNewPassword("fenix")
+            clickGoBackButton()
+            verifyLoginItemUsername("mozilla")
+            revealPassword()
+            verifyPasswordSaved("firefox")
+        }
+    }
+
+    @Test
+    fun verifyDeleteLoginButtonTest() {
+        val loginPage = TestAssetHelper.getSaveLoginAsset(mockWebServer)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(loginPage.url) {
+            verifySaveLoginPromptIsShown()
+            saveLoginFromPrompt("Save")
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openLoginsAndPasswordSubMenu {
+        }.openSavedLogins {
+            tapSetupLater()
+            viewSavedLoginDetails("test@example.com")
+            clickThreeDotButton(activityTestRule)
+            clickDeleteLoginButton()
+            verifyLoginDeletionPrompt()
+            clickCancelDeleteLogin()
+            verifyLoginItemUsername("test@example.com")
+            viewSavedLoginDetails("test@example.com")
+            clickThreeDotButton(activityTestRule)
+            clickDeleteLoginButton()
+            verifyLoginDeletionPrompt()
+            clickConfirmDeleteLogin()
+            // The account remains displayed, see: https://github.com/mozilla-mobile/fenix/issues/23212
+            // verifyNotSavedLoginFromPrompt()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/LoginsTest.kt
@@ -1,0 +1,175 @@
+package org.mozilla.fenix.ui
+
+import android.os.Build
+import android.view.autofill.AutofillManager
+import androidx.core.net.toUri
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.TestHelper
+import org.mozilla.fenix.ui.robots.browserScreen
+import org.mozilla.fenix.ui.robots.navigationToolbar
+
+class LoginsTest {
+    private lateinit var mDevice: UiDevice
+    private lateinit var mockWebServer: MockWebServer
+
+    @get:Rule
+    val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
+
+    @Before
+    fun setUp() {
+        mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        TestHelper.appContext.settings().userOptOutOfReEngageCookieBannerDialog = true
+        mockWebServer = MockWebServer().apply {
+            dispatcher = AndroidAssetDispatcher()
+            start()
+        }
+
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {
+            val autofillManager: AutofillManager =
+                TestHelper.appContext.getSystemService(AutofillManager::class.java)
+            autofillManager.disableAutofillServices()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun saveLoginFromPromptTest() {
+        val saveLoginTest =
+            TestAssetHelper.getSaveLoginAsset(mockWebServer)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(saveLoginTest.url) {
+            verifySaveLoginPromptIsShown()
+            // Click save to save the login
+            saveLoginFromPrompt("Save")
+        }
+        browserScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+            TestHelper.scrollToElementByText("Logins and passwords")
+        }.openLoginsAndPasswordSubMenu {
+            verifyDefaultView()
+        }.openSavedLogins {
+            verifySecurityPromptForLogins()
+            tapSetupLater()
+            // Verify that the login appears correctly
+            verifySavedLoginFromPrompt("test@example.com")
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun openWebsiteForSavedLoginTest() {
+        val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
+        val originWebsite = "mozilla-mobile.github.io"
+        val userName = "test"
+        val password = "pass"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(loginPage.toUri()) {
+            fillAndSubmitLoginCredentials(userName, password)
+            saveLoginFromPrompt("Save")
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openLoginsAndPasswordSubMenu {
+        }.openSavedLogins {
+            verifySecurityPromptForLogins()
+            tapSetupLater()
+            viewSavedLoginDetails(userName)
+        }.goToSavedWebsite {
+            verifyUrl(originWebsite)
+        }
+    }
+
+    @Test
+    fun neverSaveLoginFromPromptTest() {
+        val saveLoginTest = TestAssetHelper.getSaveLoginAsset(mockWebServer)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(saveLoginTest.url) {
+            verifySaveLoginPromptIsShown()
+            // Don't save the login, add to exceptions
+            saveLoginFromPrompt("Never save")
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openLoginsAndPasswordSubMenu {
+            verifyDefaultView()
+        }.openSavedLogins {
+            verifySecurityPromptForLogins()
+            tapSetupLater()
+            // Verify that the login list is empty
+            verifyNotSavedLoginFromPrompt()
+        }.goBack {
+        }.openLoginExceptions {
+            // Verify localhost was added to exceptions list
+            verifyLocalhostExceptionAdded()
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun updateSavedLoginTest() {
+        val saveLoginTest =
+            TestAssetHelper.getSaveLoginAsset(mockWebServer)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(saveLoginTest.url) {
+            verifySaveLoginPromptIsShown()
+            // Click Save to save the login
+            saveLoginFromPrompt("Save")
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(saveLoginTest.url) {
+            enterPassword("test")
+            verifyUpdateLoginPromptIsShown()
+            // Click Update to change the saved password
+            saveLoginFromPrompt("Update")
+        }.openThreeDotMenu {
+        }.openSettings {
+            TestHelper.scrollToElementByText("Logins and passwords")
+        }.openLoginsAndPasswordSubMenu {
+        }.openSavedLogins {
+            verifySecurityPromptForLogins()
+            tapSetupLater()
+            // Verify that the login appears correctly
+            verifySavedLoginFromPrompt("test@example.com")
+            viewSavedLoginDetails("test@example.com")
+            revealPassword()
+            verifyPasswordSaved("test") // failing here locally
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun verifyMultipleLoginsSelectionsTest() {
+        val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(loginPage.toUri()) {
+            fillAndSubmitLoginCredentials("mozilla", "firefox")
+            saveLoginFromPrompt("Save")
+            fillAndSubmitLoginCredentials("firefox", "mozilla")
+            saveLoginFromPrompt("Save")
+            clearUserNameLoginCredential()
+            clickSuggestedLoginsButton()
+            verifySuggestedUserName("firefox")
+            verifySuggestedUserName("mozilla")
+            clickLoginSuggestion("mozilla")
+            verifyPrefilledLoginCredentials("mozilla")
+        }
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -604,7 +604,7 @@ class SettingsPrivacyTest {
             }.openSavedLogins {
                 verifySecurityPromptForLogins()
                 tapSetupLater()
-                verifySavedLoginFromPrompt("mozilla")
+                verifySavedLoginsSectionUsername("mozilla")
             }
 
             addToHomeScreen {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -204,56 +204,6 @@ class SettingsPrivacyTest {
     }
 
     @Test
-    fun saveLoginFromPromptTest() {
-        val saveLoginTest =
-            TestAssetHelper.getSaveLoginAsset(mockWebServer)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(saveLoginTest.url) {
-            verifySaveLoginPromptIsShown()
-            // Click save to save the login
-            saveLoginFromPrompt("Save")
-        }
-        browserScreen {
-        }.openThreeDotMenu {
-        }.openSettings {
-            TestHelper.scrollToElementByText("Logins and passwords")
-        }.openLoginsAndPasswordSubMenu {
-            verifyDefaultView()
-        }.openSavedLogins {
-            verifySecurityPromptForLogins()
-            tapSetupLater()
-            // Verify that the login appears correctly
-            verifySavedLoginFromPrompt("test@example.com")
-        }
-    }
-
-    @Test
-    fun neverSaveLoginFromPromptTest() {
-        val saveLoginTest = TestAssetHelper.getSaveLoginAsset(mockWebServer)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(saveLoginTest.url) {
-            verifySaveLoginPromptIsShown()
-            // Don't save the login, add to exceptions
-            saveLoginFromPrompt("Never save")
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.openLoginsAndPasswordSubMenu {
-            verifyDefaultView()
-        }.openSavedLogins {
-            verifySecurityPromptForLogins()
-            tapSetupLater()
-            // Verify that the login list is empty
-            verifyNotSavedLoginFromPrompt()
-        }.goBack {
-        }.openLoginExceptions {
-            // Verify localhost was added to exceptions list
-            verifyLocalhostExceptionAdded()
-        }
-    }
-
-    @Test
     fun saveLoginsAndPasswordsOptions() {
         homeScreen {
         }.openThreeDotMenu {
@@ -261,50 +211,6 @@ class SettingsPrivacyTest {
         }.openLoginsAndPasswordSubMenu {
         }.saveLoginsAndPasswordsOptions {
             verifySaveLoginsOptionsView()
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun openWebsiteForSavedLoginTest() {
-        val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
-        val originWebsite = "mozilla-mobile.github.io"
-        val userName = "test"
-        val password = "pass"
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(loginPage.toUri()) {
-            fillAndSubmitLoginCredentials(userName, password)
-            saveLoginFromPrompt("Save")
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.openLoginsAndPasswordSubMenu {
-        }.openSavedLogins {
-            verifySecurityPromptForLogins()
-            tapSetupLater()
-            viewSavedLoginDetails(userName)
-        }.goToSavedWebsite {
-            verifyUrl(originWebsite)
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun verifyMultipleLoginsSelectionsTest() {
-        val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(loginPage.toUri()) {
-            fillAndSubmitLoginCredentials("mozilla", "firefox")
-            saveLoginFromPrompt("Save")
-            fillAndSubmitLoginCredentials("firefox", "mozilla")
-            saveLoginFromPrompt("Save")
-            clearUserNameLoginCredential()
-            clickSuggestedLoginsButton()
-            verifySuggestedUserName("firefox")
-            verifySuggestedUserName("mozilla")
-            clickLoginSuggestion("mozilla")
-            verifyPrefilledLoginCredentials("mozilla")
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -30,7 +30,6 @@ import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.appName
 import org.mozilla.fenix.helpers.TestHelper.assertNativeAppOpens
 import org.mozilla.fenix.helpers.TestHelper.createCustomTabIntent
@@ -363,38 +362,6 @@ class SmokeTest {
             }.submitQuery("mozilla ") {
                 verifyUrl(searchEngine)
             }.goToHomescreen { }
-        }
-    }
-
-    // Saves a login, then changes it and verifies the update
-    @Test
-    fun updateSavedLoginTest() {
-        val saveLoginTest =
-            TestAssetHelper.getSaveLoginAsset(mockWebServer)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(saveLoginTest.url) {
-            verifySaveLoginPromptIsShown()
-            // Click Save to save the login
-            saveLoginFromPrompt("Save")
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(saveLoginTest.url) {
-            enterPassword("test")
-            verifyUpdateLoginPromptIsShown()
-            // Click Update to change the saved password
-            saveLoginFromPrompt("Update")
-        }.openThreeDotMenu {
-        }.openSettings {
-            TestHelper.scrollToElementByText("Logins and passwords")
-        }.openLoginsAndPasswordSubMenu {
-        }.openSavedLogins {
-            verifySecurityPromptForLogins()
-            tapSetupLater()
-            // Verify that the login appears correctly
-            verifySavedLoginFromPrompt("test@example.com")
-            viewSavedLoginDetails("test@example.com")
-            revealPassword()
-            verifyPasswordSaved("test") // failing here locally
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -564,13 +564,16 @@ class BrowserRobot {
         )
     }
 
-    fun verifyPrefilledLoginCredentials(userName: String) {
+    fun verifyPrefilledLoginCredentials(userName: String, password: String) {
         var currentTries = 0
         // Sometimes the assertion of the pre-filled logins fails so we are re-trying after refreshing the page
         while (currentTries++ < 3) {
             try {
                 mDevice.waitForObjects(webPageItemWithResourceId("username"))
                 assertTrue(webPageItemWithResourceId("username").text.equals(userName))
+
+                mDevice.waitForObjects(webPageItemWithResourceId("password"))
+                assertTrue(webPageItemWithResourceId("password").text.equals(password))
 
                 break
             } catch (e: AssertionError) {
@@ -581,11 +584,14 @@ class BrowserRobot {
                     clickSuggestedLoginsButton()
                     verifySuggestedUserName(userName)
                     clickLoginSuggestion(userName)
+                    clickShowPasswordButton()
                 }
             }
         }
         mDevice.waitForObjects(webPageItemWithResourceId("username"))
         assertTrue(webPageItemWithResourceId("username").text.equals(userName))
+        mDevice.waitForObjects(webPageItemWithResourceId("password"))
+        assertTrue(webPageItemWithResourceId("password").text.equals(password))
     }
 
     fun verifyAutofilledAddress(streetAddress: String) {
@@ -907,6 +913,12 @@ class BrowserRobot {
         }
         assertItemWithResIdExists(cookieBanner, exists = exists)
     }
+
+    fun clickShowPasswordButton() =
+        itemWithResId("togglePassword").also {
+            it.waitForExists(waitingTime)
+            it.click()
+        }
 
     class Transition {
         private fun threeDotButton() = onView(

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot.kt
@@ -5,9 +5,11 @@
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
@@ -18,8 +20,14 @@ import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.containsString
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.mDevice
+import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
@@ -40,8 +48,10 @@ class SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot {
 
     fun tapSetupLater() = onView(withText("Later")).perform(ViewActions.click())
 
-    fun verifySavedLoginFromPrompt(userName: String) =
-        mDevice.waitNotNull(Until.findObjects(By.text(userName)))
+    fun verifySavedLoginsSectionUsername(username: String) =
+        mDevice.waitNotNull(Until.findObjects(By.text(username)))
+
+    fun verifyLoginItemUsername(username: String) = assertItemContainingTextExists(itemContainingText(username))
 
     fun verifyNotSavedLoginFromPrompt() = onView(withText("test@example.com"))
         .check(ViewAssertions.doesNotExist())
@@ -51,10 +61,41 @@ class SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot {
 
     fun viewSavedLoginDetails(loginUserName: String) = onView(withText(loginUserName)).click()
 
+    fun clickThreeDotButton(activityTestRule: HomeActivityIntentTestRule) =
+        openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+
+    fun clickEditLoginButton() = itemContainingText("Edit").click()
+
+    fun clickDeleteLoginButton() = itemContainingText("Delete").click()
+
+    fun verifyLoginDeletionPrompt() =
+        assertItemContainingTextExists(itemContainingText(getStringResource(R.string.login_deletion_confirmation)))
+
+    fun clickConfirmDeleteLogin() =
+        onView(withId(android.R.id.button1)).inRoot(RootMatchers.isDialog()).click()
+
+    fun clickCancelDeleteLogin() =
+        onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).click()
+
+    fun setNewUserName(userName: String) = itemWithResId("$packageName:id/usernameText").setText(userName)
+
+    fun clickClearUserNameButton() = itemWithResId("$packageName:id/clearUsernameTextButton").click()
+
+    fun setNewPassword(password: String) = itemWithResId("$packageName:id/passwordText").setText(password)
+
+    fun clickClearPasswordButton() = itemWithResId("$packageName:id/clearPasswordTextButton").click()
+
+    fun saveEditedLogin() = itemWithResId("$packageName:id/save_login_button").click()
+
     fun revealPassword() = onView(withId(R.id.revealPasswordButton)).click()
 
     fun verifyPasswordSaved(password: String) =
         onView(withId(R.id.passwordText)).check(matches(withText(password)))
+
+    fun verifyPasswordRequiredErrorMessage() =
+        assertItemContainingTextExists(itemContainingText(getStringResource(R.string.saved_login_password_required)))
+
+    fun clickGoBackButton() = goBackButton().click()
 
     class Transition {
         fun goBack(interact: SettingsSubMenuLoginsAndPasswordRobot.() -> Unit): SettingsSubMenuLoginsAndPasswordRobot.Transition {


### PR DESCRIPTION
Bug 1810565 - Part 1: New logins related UI tests and other refactoring work.

Summary:
1. Moved existing logins related UI tests from `SettingsPrivacyTest` and `SmokeTest` to a new `LoginsTest` test class.
2. Created new UI tests to improve the "Full functional" test suite coverage.
`verifyEditLoginsViewTest` ✅ successfully passed 100x on Firebase
`verifyEditedLoginsAreSavedTest` ✅ successfully passed 100x on Firebase
`verifyLoginWithNoUserNameCanBeSavedTest` ✅ successfully passed 100x on Firebase
`verifyLoginWithoutPasswordCanNotBeSavedTest` ✅ successfully passed 100x on Firebase
`verifyEditModeDismissalDoesNotSaveLoginCredentialsTest` ✅ successfully passed 100x on Firebase
`verifyDeleteLoginButtonTest` ✅ successfully passed 100x on Firebase

❗ Note before landing: 
Added a [password visibility icon to loginForm.html in V2.0](https://github.com/mozilla-mobile/testapp/pull/13)
Will need to update the website links [here](https://github.com/mozilla-mobile/fenix/pull/28528/commits/f34926fc2ca54164380fb47942885f53a2b0c743#diff-cd97fd7ad728c6afe89857c60f998fb6c18f65c215e605db1874e61d5aa61c7aR160) and [here](https://github.com/mozilla-mobile/fenix/pull/28528/commits/f34926fc2ca54164380fb47942885f53a2b0c743#diff-cd97fd7ad728c6afe89857c60f998fb6c18f65c215e605db1874e61d5aa61c7aR204) after the change to `loginForm.html` will land

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
4. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
5. Click on the `build-debug` task.
6. Click on `View task in Taskcluster` in the new `DETAILS` section.
7. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
