### PR TITLE
Bug 1810115 - Add telemetry for notification pre permission prompt

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -871,6 +871,74 @@ onboarding:
     metadata:
       tags:
         - Onboarding
+  notif_ppp_impression:
+    type: event
+    description: |
+      Notification pre permission prompt was shown to the user.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1810115
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/28529
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 124
+    metadata:
+      tags:
+        - Notifications
+        - Onboarding
+  notif_ppp_close_click:
+    type: event
+    description: |
+      User clicked the close button on the notification pre permission prompt.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1810115
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/28529
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 124
+    metadata:
+      tags:
+        - Notifications
+        - Onboarding
+  notif_ppp_positive_btn_click:
+    type: event
+    description: |
+      User clicked the positive button on notification pre permission prompt.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1810115
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/28529
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 124
+    metadata:
+      tags:
+        - Notifications
+        - Onboarding
+  notif_ppp_negative_btn_click:
+    type: event
+    description: |
+      User clicked the negative button on notification pre permission prompt.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1810115
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/28529
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 124
+    metadata:
+      tags:
+        - Notifications
+        - Onboarding
 
 search_shortcuts:
   selected:

--- a/app/src/main/java/org/mozilla/fenix/onboarding/view/NotificationPermissionDialogScreen.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/view/NotificationPermissionDialogScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.insets.navigationBarsPadding
 import com.google.accompanist.insets.statusBarsPadding
+import mozilla.components.service.glean.private.NoExtras
+import org.mozilla.fenix.GleanMetrics.Onboarding
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.button.PrimaryButton
 import org.mozilla.fenix.compose.button.SecondaryButton
@@ -69,9 +71,18 @@ fun NotificationPermissionDialogScreen(
 ) {
     NotificationPermissionContent(
         notificationPermissionPageState = NotificationPageState,
-        onDismiss = onDismiss,
-        onPrimaryButtonClick = grantNotificationPermission,
-        onSecondaryButtonClick = onDismiss,
+        onDismiss = {
+            onDismiss()
+            Onboarding.notifPppCloseClick.record(NoExtras())
+        },
+        onPrimaryButtonClick = {
+            grantNotificationPermission()
+            Onboarding.notifPppPositiveBtnClick.record(NoExtras())
+        },
+        onSecondaryButtonClick = {
+            onDismiss()
+            Onboarding.notifPppNegativeBtnClick.record(NoExtras())
+        },
     )
 }
 
@@ -205,7 +216,7 @@ private val NotificationPageState = NotificationPermissionPageState(
     description = R.string.onboarding_home_enable_notifications_description,
     primaryButtonText = R.string.onboarding_home_enable_notifications_positive_button,
     secondaryButtonText = R.string.onboarding_home_enable_notifications_negative_button,
-    onRecordImpressionEvent = {},
+    onRecordImpressionEvent = { Onboarding.notifPppImpression.record(NoExtras()) },
 )
 
 private const val IMAGE_HEIGHT_RATIO = 0.4f


### PR DESCRIPTION
Adds impression, close click, positive button click and negative button click events.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
