### PR TITLE
Add android version to nimbus targeting

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NimbusTests.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NimbusTests.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.Experimentation
+import org.mozilla.fenix.helpers.RetryTestRule
+
+class NimbusTests {
+    private lateinit var mDevice: UiDevice
+    private lateinit var mockWebServer: MockWebServer
+
+    @Rule
+    @JvmField
+    val retryTestRule = RetryTestRule(3)
+
+    @Before
+    fun setUp() {
+        mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        mockWebServer = MockWebServer().apply {
+            dispatcher = AndroidAssetDispatcher()
+            start()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun androidVersionTest() {
+        Experimentation.withHelper {
+            assertTrue(evalJexl("android_version > 0"))
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
+++ b/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.experiments
 
 import android.content.Context
+import android.os.Build
 import mozilla.components.service.nimbus.NimbusApi
 import mozilla.components.service.nimbus.NimbusAppInfo
 import mozilla.components.service.nimbus.NimbusBuilder
@@ -42,6 +43,7 @@ fun createNimbus(context: Context, urlString: String?): NimbusApi {
         // This camelCase attribute is a boolean value represented as a string.
         // This is left for backwards compatibility.
         put("isFirstRun", isAppFirstRun.toString())
+        put("android_version", Build.VERSION.SDK_INT)
     }
 
     // The name "fenix" here corresponds to the app_name defined for the family of apps


### PR DESCRIPTION
This adds the Android OS version to the Nimbus targeting context. This will allow for new experiments to target specific Android versions.

Pre-permission prompt experiment brief explaining the need for this feature: https://docs.google.com/document/d/1yPqTWGtJ8DPrlUoVqtX8AOtpMCoE7WGdb7R4l9BqYT4/edit#heading=h.j0lsegsodnsd

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**
  - Personally, with the UI test validating the nimbus targeting variable is in place, I don't think it needs dedicated QA.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
