### PR TITLE
Bug 1809921 - Address crash when visiting internal sites like about config when cookie banner is ON

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -35,6 +35,7 @@ import mozilla.components.lib.state.ext.consumeFlow
 import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
 import org.mozilla.fenix.GleanMetrics.ReaderMode
 import org.mozilla.fenix.R
@@ -49,6 +50,7 @@ import org.mozilla.fenix.ext.runIfFragmentIsAttached
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.nimbus.FxNimbus
 import org.mozilla.fenix.settings.quicksettings.protections.cookiebanners.dialog.CookieBannerReEngagementDialogUtils
+import org.mozilla.fenix.settings.quicksettings.protections.cookiebanners.safeHasException
 import org.mozilla.fenix.shortcut.PwaOnboardingObserver
 import org.mozilla.fenix.theme.ThemeManager
 
@@ -60,6 +62,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
 
     private val windowFeature = ViewBoundFeatureWrapper<WindowFeature>()
     private val openInAppOnboardingObserver = ViewBoundFeatureWrapper<OpenInAppOnboardingObserver>()
+    private val logger = Logger("BaseBrowserFragment")
 
     private var readerModeAvailable = false
     private var pwaOnboardingObserver: PwaOnboardingObserver? = null
@@ -382,10 +385,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 val hasCookieBannerException =
                     if (requireContext().settings().shouldUseCookieBanner) {
                         withContext(Dispatchers.IO) {
-                            cookieBannersStorage.hasException(
-                                tab.content.url,
-                                tab.content.private,
-                            )
+                            cookieBannersStorage.safeHasException(tab, logger)
                         }
                     } else {
                         false

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -27,18 +27,19 @@ import mozilla.components.feature.pwa.feature.WebAppHideToolbarFeature
 import mozilla.components.feature.pwa.feature.WebAppSiteControlsFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.arch.lifecycle.addObservers
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BaseBrowserFragment
 import org.mozilla.fenix.browser.CustomTabContextMenuCandidate
 import org.mozilla.fenix.browser.FenixSnackbarDelegate
-import org.mozilla.fenix.components.components
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.runIfFragmentIsAttached
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.settings.quicksettings.protections.cookiebanners.safeHasException
 
 /**
  * Fragment used for browsing the web within external apps.
@@ -50,6 +51,7 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
     private val customTabsIntegration = ViewBoundFeatureWrapper<CustomTabsIntegration>()
     private val windowFeature = ViewBoundFeatureWrapper<CustomTabWindowFeature>()
     private val hideToolbarFeature = ViewBoundFeatureWrapper<WebAppHideToolbarFeature>()
+    private val logger = Logger("ExternalAppBrowserFragment")
 
     @Suppress("LongMethod", "ComplexMethod")
     override fun initializeUI(view: View, tab: SessionState) {
@@ -168,7 +170,7 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
         requireComponents.useCases.trackingProtectionUseCases.containsException(tab.id) { contains ->
             lifecycleScope.launch(Dispatchers.IO) {
                 val hasException = if (requireContext().settings().shouldUseCookieBanner) {
-                    cookieBannersStorage.hasException(tab.content.url, tab.content.private)
+                    cookieBannersStorage.safeHasException(tab, logger)
                 } else {
                     false
                 }

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/ConnectionDetailsController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/ConnectionDetailsController.kt
@@ -14,10 +14,12 @@ import kotlinx.coroutines.withContext
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.concept.engine.cookiehandling.CookieBannersStorage
 import mozilla.components.concept.engine.permission.SitePermissions
+import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.browser.BrowserFragmentDirections
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.runIfFragmentIsAttached
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.settings.quicksettings.protections.cookiebanners.safeHasException
 
 /**
  * [ConnectionDetailsController] controller.
@@ -46,13 +48,14 @@ class DefaultConnectionDetailsController(
     private val gravity: Int,
     private val getCurrentTab: () -> SessionState?,
 ) : ConnectionDetailsController {
+    private val logger = Logger("ConnectionDetailsController")
 
     override fun handleBackPressed() {
         getCurrentTab()?.let { tab ->
             context.components.useCases.trackingProtectionUseCases.containsException(tab.id) { contains ->
                 ioScope.launch {
                     val hasException = if (context.settings().shouldUseCookieBanner) {
-                        cookieBannersStorage.hasException(tab.content.url, tab.content.private)
+                        cookieBannersStorage.safeHasException(tab, logger)
                     } else {
                         false
                     }

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/CookieBannerDetailsController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/CookieBannerDetailsController.kt
@@ -22,6 +22,7 @@ import mozilla.components.concept.engine.permission.SitePermissions
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.service.glean.private.NoExtras
+import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.GleanMetrics.CookieBanners
 import org.mozilla.fenix.browser.BrowserFragmentDirections
 import org.mozilla.fenix.ext.components
@@ -68,13 +69,14 @@ class DefaultCookieBannerDetailsController(
     private val engine: Engine = context.components.core.engine,
     private val publicSuffixList: PublicSuffixList = context.components.publicSuffixList,
 ) : CookieBannerDetailsController {
+    private val logger = Logger("TrackingProtectionPanelInteractor")
 
     override fun handleBackPressed() {
         getCurrentTab()?.let { tab ->
             context.components.useCases.trackingProtectionUseCases.containsException(tab.id) { contains ->
                 ioScope.launch {
                     val hasException = if (context.settings().shouldUseCookieBanner) {
-                        cookieBannersStorage.hasException(tab.content.url, tab.content.private)
+                        cookieBannersStorage.safeHasException(tab, logger)
                     } else {
                         false
                     }

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/CookieBannerUtil.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/CookieBannerUtil.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.quicksettings.protections.cookiebanners
+
+import mozilla.components.browser.state.state.SessionState
+import mozilla.components.concept.engine.cookiehandling.CookieBannersStorage
+import mozilla.components.support.base.log.logger.Logger
+
+/**
+ * Queries [CookieBannersStorage.hasException] and handles unexpected exceptions.
+ */
+@Suppress("TooGenericExceptionCaught")
+suspend inline fun CookieBannersStorage.safeHasException(tab: SessionState, logger: Logger): Boolean {
+    return try {
+        hasException(
+            tab.content.url,
+            tab.content.private,
+        )
+    } catch (e: Exception) {
+        // This normally happen on internal sites like about:config
+        logger.error("Unable to query cookie banners exception")
+        false
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelInteractor.kt
@@ -14,10 +14,12 @@ import kotlinx.coroutines.withContext
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.concept.engine.cookiehandling.CookieBannersStorage
 import mozilla.components.concept.engine.permission.SitePermissions
+import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.browser.BrowserFragmentDirections
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.runIfFragmentIsAttached
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.settings.quicksettings.protections.cookiebanners.safeHasException
 
 /**
  * Interactor for the tracking protection panel
@@ -37,6 +39,7 @@ class TrackingProtectionPanelInteractor(
     private val gravity: Int,
     private val getCurrentTab: () -> SessionState?,
 ) : TrackingProtectionPanelViewInteractor {
+    private val logger = Logger("TrackingProtectionPanelInteractor")
 
     override fun openDetails(category: TrackingProtectionCategory, categoryBlocked: Boolean) {
         store.dispatch(ProtectionsAction.EnterDetailsMode(category, categoryBlocked))
@@ -55,7 +58,7 @@ class TrackingProtectionPanelInteractor(
             context.components.useCases.trackingProtectionUseCases.containsException(tab.id) { contains ->
                 ioScope.launch {
                     val hasException = if (context.settings().shouldUseCookieBanner) {
-                        cookieBannersStorage.hasException(tab.content.url, tab.content.private)
+                        cookieBannersStorage.safeHasException(tab, logger)
                     } else {
                         false
                     }


### PR DESCRIPTION
To reproduce visit, `about:config` when cookie banner handling is ON, then tab the shield icon.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
