### PR TITLE
Bug 1810528 - New PDFs open and save UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -7,10 +7,12 @@ package org.mozilla.fenix.ui
 import androidx.core.net.toUri
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.TestHelper.assertExternalAppOpens
 import org.mozilla.fenix.helpers.TestHelper.deleteDownloadedFileOnStorage
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.ui.robots.browserScreen
@@ -30,6 +32,9 @@ class DownloadTest {
     /* Remote test page managed by Mozilla Mobile QA team at https://github.com/mozilla-mobile/testapp */
     private val downloadTestPage = "https://storage.googleapis.com/mobile_test_assets/test_app/downloads.html"
     private var downloadFile: String = ""
+    private val pdfFileName = "washington.pdf"
+    private val pdfFileURL = "storage.googleapis.com/mobile_test_assets/public/washington.pdf"
+    private val pdfFileContent = "Washington Crossing the Delaware"
 
     @get:Rule
     val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
@@ -182,6 +187,36 @@ class DownloadTest {
             openDownloadedFile(downloadFile)
             verifyPhotosAppOpens()
             mDevice.pressBack()
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun openPDFInBrowserTest() {
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(downloadTestPage.toUri()) {
+            clickLinkMatchingText(pdfFileName)
+            verifyUrl(pdfFileURL)
+            verifyPageContent(pdfFileContent)
+        }
+    }
+
+    @Ignore("Failing because of https://bugzilla.mozilla.org/show_bug.cgi?id=1810132")
+    @SmokeTest
+    @Test
+    fun saveAndOpenPdfTest() {
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(downloadTestPage.toUri()) {
+            clickLinkMatchingText(pdfFileName)
+            verifyPageContent(pdfFileContent)
+        }.openThreeDotMenu {
+        }.clickShareButton {
+        }.clickSaveAsPDF {
+            // change back to simple filename
+            verifyDownloadPrompt(pdfFileName)
+        }.clickDownload {
+        }.clickOpen("application/pdf") {
+            assertExternalAppOpens("com.google.android.apps.docs")
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
@@ -90,6 +90,7 @@ class DownloadRobot {
         }
 
         fun clickOpen(type: String, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            openDownloadButton().waitForExists(waitingTime)
             openDownloadButton().click()
 
             // verify open intent is matched with associated data type
@@ -186,13 +187,12 @@ private fun closePromptButton() =
     onView(withContentDescription("Close"))
 
 private fun downloadButton() =
-    onView(withText("Download"))
+    onView(withId(R.id.download_button))
         .inRoot(isDialog())
         .check(matches(isDisplayed()))
 
 private fun openDownloadButton() =
-    onView(withId(R.id.download_dialog_action_button))
-        .check(matches(isDisplayed()))
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/download_dialog_action_button"))
 
 private fun downloadedFile(fileName: String) = onView(withText(fileName))
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ShareOverlayRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ShareOverlayRobot.kt
@@ -20,6 +20,7 @@ import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers.allOf
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
@@ -71,7 +72,14 @@ class ShareOverlayRobot {
         )
     }
 
-    class Transition
+    class Transition {
+        fun clickSaveAsPDF(interact: DownloadRobot.() -> Unit): DownloadRobot.Transition {
+            itemContainingText("Save as PDF").click()
+
+            DownloadRobot().interact()
+            return DownloadRobot.Transition()
+        }
+    }
 }
 
 private fun shareTabsLayout() = onView(withResourceName("shareWrapper"))


### PR DESCRIPTION
Follow-up bug, to re-enable saveAndOpenPdfTest: https://bugzilla.mozilla.org/show_bug.cgi?id=1810531

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
