### PR TITLE
Bug 1810735 - Part 2: New logins related UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -209,7 +209,7 @@ class SettingsPrivacyTest {
         }.openThreeDotMenu {
         }.openSettings {
         }.openLoginsAndPasswordSubMenu {
-        }.saveLoginsAndPasswordsOptions {
+        }.openSaveLoginsAndPasswordsOptions {
             verifySaveLoginsOptionsView()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -403,12 +403,9 @@ class BrowserRobot {
         switchButton.clickAndWaitForNewWindow(waitingTime)
     }
 
-    fun verifySaveLoginPromptIsShown() = clickPageObject(webPageItemWithResourceId("submit"))
+    fun clickSubmitLoginButton() = clickPageObject(webPageItemWithResourceId("submit"))
 
-    fun verifyUpdateLoginPromptIsShown() {
-        clickPageObject(webPageItemWithResourceId("submit"))
-        mDevice.waitNotNull(Until.findObjects(text("Update")))
-    }
+    fun verifyUpdateLoginPromptIsShown() = mDevice.waitNotNull(Until.findObjects(text("Update")))
 
     fun saveLoginFromPrompt(optionToSaveLogin: String) {
         mDevice.waitForObjects(
@@ -504,6 +501,12 @@ class BrowserRobot {
         mDevice.waitForIdle(waitingTime)
     }
 
+    fun clickUsernameTextField() =
+        webPageItemWithResourceId("username").also {
+            it.waitForExists(waitingTime)
+            it.click()
+        }
+
     fun clickSuggestedLoginsButton() {
         var currentTries = 0
         while (currentTries++ < 3) {
@@ -564,34 +567,41 @@ class BrowserRobot {
         )
     }
 
-    fun verifyPrefilledLoginCredentials(userName: String, password: String) {
-        var currentTries = 0
+    fun verifyPrefilledLoginCredentials(userName: String, password: String, credentialsArePrefilled: Boolean) {
         // Sometimes the assertion of the pre-filled logins fails so we are re-trying after refreshing the page
-        while (currentTries++ < 3) {
+        for (i in 1..RETRY_COUNT) {
             try {
-                mDevice.waitForObjects(webPageItemWithResourceId("username"))
-                assertTrue(webPageItemWithResourceId("username").text.equals(userName))
+                if (credentialsArePrefilled) {
+                    mDevice.waitForObjects(webPageItemWithResourceId("username"))
+                    assertTrue(webPageItemWithResourceId("username").text.equals(userName))
 
-                mDevice.waitForObjects(webPageItemWithResourceId("password"))
-                assertTrue(webPageItemWithResourceId("password").text.equals(password))
+                    mDevice.waitForObjects(webPageItemWithResourceId("password"))
+                    assertTrue(webPageItemWithResourceId("password").text.equals(password))
+                } else {
+                    mDevice.waitForObjects(webPageItemWithResourceId("username"))
+                    assertFalse(webPageItemWithResourceId("username").text.equals(userName))
+
+                    mDevice.waitForObjects(webPageItemWithResourceId("password"))
+                    assertFalse(webPageItemWithResourceId("password").text.equals(password))
+                }
 
                 break
             } catch (e: AssertionError) {
-                browserScreen {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    clearUserNameLoginCredential()
-                    clickSuggestedLoginsButton()
-                    verifySuggestedUserName(userName)
-                    clickLoginSuggestion(userName)
-                    clickShowPasswordButton()
+                if (i == RETRY_COUNT) {
+                    throw e
+                } else {
+                    browserScreen {
+                    }.openThreeDotMenu {
+                    }.refreshPage {
+                        clearUserNameLoginCredential()
+                        clickSuggestedLoginsButton()
+                        verifySuggestedUserName(userName)
+                        clickLoginSuggestion(userName)
+                        clickShowPasswordButton()
+                    }
                 }
             }
         }
-        mDevice.waitForObjects(webPageItemWithResourceId("username"))
-        assertTrue(webPageItemWithResourceId("username").text.equals(userName))
-        mDevice.waitForObjects(webPageItemWithResourceId("password"))
-        assertTrue(webPageItemWithResourceId("password").text.equals(password))
     }
 
     fun verifyAutofilledAddress(streetAddress: String) {
@@ -635,6 +645,12 @@ class BrowserRobot {
             ).waitForExists(waitingTime),
         )
     }
+
+    fun verifySaveLoginPromptIsNotDisplayed() =
+        assertItemWithResIdExists(
+            itemWithResId("$packageName:id/feature_prompt_login_fragment"),
+            exists = false,
+        )
 
     fun verifyTrackingProtectionWebContent(state: String) {
         for (i in 1..RETRY_COUNT) {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordOptionsToSaveRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordOptionsToSaveRobot.kt
@@ -8,8 +8,17 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.not
+import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
 
 /**
  * Implementation of Robot Pattern for the Privacy Settings > saved logins sub menu
@@ -17,12 +26,51 @@ import org.hamcrest.CoreMatchers
 
 class SettingsSubMenuLoginsAndPasswordOptionsToSaveRobot {
     fun verifySaveLoginsOptionsView() {
-        onView(ViewMatchers.withText("Ask to save"))
+        onView(withText("Ask to save"))
             .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
-        onView(ViewMatchers.withText("Never save"))
+        onView(withText("Never save"))
             .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
     }
+
+    fun verifyAskToSaveRadioButton(isChecked: Boolean) {
+        if (isChecked) {
+            onView(
+                allOf(
+                    withId(R.id.radio_button),
+                    hasSibling(withText(R.string.preferences_passwords_save_logins_ask_to_save)),
+                ),
+            ).check(matches(isChecked()))
+        } else {
+            onView(
+                allOf(
+                    withId(R.id.radio_button),
+                    hasSibling(withText(R.string.preferences_passwords_save_logins_ask_to_save)),
+                ),
+            ).check(matches(not(isChecked())))
+        }
+    }
+
+    fun verifyNeverSaveSaveRadioButton(isChecked: Boolean) {
+        if (isChecked) {
+            onView(
+                allOf(
+                    withId(R.id.radio_button),
+                    hasSibling(withText(R.string.preferences_passwords_save_logins_never_save)),
+                ),
+            ).check(matches(isChecked()))
+        } else {
+            onView(
+                allOf(
+                    withId(R.id.radio_button),
+                    hasSibling(withText(R.string.preferences_passwords_save_logins_never_save)),
+                ),
+            ).check(matches(not(isChecked())))
+        }
+    }
+
+    fun clickNeverSaveOption() =
+        itemContainingText(getStringResource(R.string.preferences_passwords_save_logins_never_save)).click()
 
     class Transition {
         fun goBack(interact: SettingsSubMenuLoginsAndPasswordRobot.() -> Unit): SettingsSubMenuLoginsAndPasswordRobot.Transition {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordRobot.kt
@@ -11,12 +11,20 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isChecked
+import androidx.test.espresso.matcher.ViewMatchers.isNotChecked
+import androidx.test.espresso.matcher.ViewMatchers.withClassName
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.endsWith
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.TestHelper.appName
+import org.mozilla.fenix.helpers.TestHelper.hasCousin
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
@@ -43,6 +51,25 @@ class SettingsSubMenuLoginsAndPasswordRobot {
 
     fun verifyDefaultValueAutofillLogins(context: Context) = assertDefaultValueAutofillLogins(context)
 
+    fun clickAutofillOption() = autofillOption.click()
+
+    fun verifyAutofillToggle(enabled: Boolean) =
+        autofillOption
+            .check(
+                matches(
+                    hasCousin(
+                        allOf(
+                            withClassName(endsWith("Switch")),
+                            if (enabled) {
+                                isChecked()
+                            } else {
+                                isNotChecked()
+                            },
+                        ),
+                    ),
+                ),
+            )
+
     class Transition {
 
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
@@ -53,7 +80,7 @@ class SettingsSubMenuLoginsAndPasswordRobot {
         }
 
         fun openSavedLogins(interact: SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot.() -> Unit): SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot.Transition {
-            fun savedLoginsButton() = onView(ViewMatchers.withText("Saved logins"))
+            fun savedLoginsButton() = onView(withText("Saved logins"))
             savedLoginsButton().click()
 
             SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot().interact()
@@ -76,8 +103,8 @@ class SettingsSubMenuLoginsAndPasswordRobot {
             return SettingsTurnOnSyncRobot.Transition()
         }
 
-        fun saveLoginsAndPasswordsOptions(interact: SettingsSubMenuLoginsAndPasswordOptionsToSaveRobot.() -> Unit): SettingsSubMenuLoginsAndPasswordOptionsToSaveRobot.Transition {
-            fun saveLoginsAndPasswordButton() = onView(ViewMatchers.withText("Save logins and passwords"))
+        fun openSaveLoginsAndPasswordsOptions(interact: SettingsSubMenuLoginsAndPasswordOptionsToSaveRobot.() -> Unit): SettingsSubMenuLoginsAndPasswordOptionsToSaveRobot.Transition {
+            fun saveLoginsAndPasswordButton() = onView(withText("Save logins and passwords"))
             saveLoginsAndPasswordButton().click()
 
             SettingsSubMenuLoginsAndPasswordOptionsToSaveRobot().interact()
@@ -112,3 +139,5 @@ private fun assertDefaultValueExceptions() = onView(ViewMatchers.withText("Excep
 
 private fun assertDefaultValueSyncLogins() = onView(ViewMatchers.withText("Sync and save data"))
     .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+
+private val autofillOption = onView(withText("Autofill in $appName"))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot.kt
@@ -4,6 +4,8 @@
 
 package org.mozilla.fenix.ui.robots
 
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import androidx.test.espresso.action.ViewActions
@@ -13,15 +15,18 @@ import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withHint
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.containsString
+import org.junit.Assert.assertEquals
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemContainingTextExists
+import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemContainingText
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
 import org.mozilla.fenix.helpers.TestAssetHelper
@@ -47,6 +52,52 @@ class SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot {
     }
 
     fun tapSetupLater() = onView(withText("Later")).perform(ViewActions.click())
+
+    fun clickAddLoginButton() =
+        itemContainingText(getStringResource(R.string.preferences_logins_add_login)).click()
+
+    fun verifyAddNewLoginView() {
+        assertItemWithResIdExists(
+            siteHeader,
+            siteTextInput,
+            usernameHeader,
+            usernameTextInput,
+            passwordHeader,
+            passwordTextInput,
+        )
+        assertItemContainingTextExists(siteDescription)
+        siteTextInputHint.check(matches(withHint(R.string.add_login_hostname_hint_text)))
+    }
+
+    fun enterSiteCredential(website: String) = siteTextInput.setText(website)
+
+    fun verifyHostnameErrorMessage() =
+        assertItemContainingTextExists(itemContainingText(getStringResource(R.string.add_login_hostname_invalid_text_2)))
+
+    fun verifyPasswordErrorMessage() =
+        assertItemContainingTextExists(itemContainingText(getStringResource(R.string.saved_login_password_required)))
+
+    fun clickSearchLoginButton() = itemWithResId("$packageName:id/search").click()
+
+    fun clickSavedLoginsChevronIcon() = itemWithResId("$packageName:id/toolbar_chevron_icon").click()
+
+    fun verifyLoginsSortingOptions() {
+        assertItemContainingTextExists(itemContainingText(getStringResource(R.string.saved_logins_sort_strategy_alphabetically)))
+        assertItemContainingTextExists(itemContainingText(getStringResource(R.string.saved_logins_sort_strategy_last_used)))
+    }
+
+    fun clickLastUsedSortingOption() =
+        itemContainingText(getStringResource(R.string.saved_logins_sort_strategy_last_used)).click()
+
+    fun verifySortedLogin(testRule: HomeActivityIntentTestRule, position: Int, loginTitle: String) {
+        val list = testRule.activity.findViewById<RecyclerView>(R.id.saved_logins_list)
+        val item = list.layoutManager?.findViewByPosition(position)
+        val title = item?.findViewById<AppCompatTextView>(R.id.webAddressView)
+        assertEquals(loginTitle, title?.text)
+    }
+
+    fun searchLogin(searchTerm: String) =
+        itemContainingText(getStringResource(R.string.preferences_passwords_saved_logins_search)).setText(searchTerm)
 
     fun verifySavedLoginsSectionUsername(username: String) =
         mDevice.waitNotNull(Until.findObjects(By.text(username)))
@@ -77,11 +128,11 @@ class SettingsSubMenuLoginsAndPasswordsSavedLoginsRobot {
     fun clickCancelDeleteLogin() =
         onView(withId(android.R.id.button2)).inRoot(RootMatchers.isDialog()).click()
 
-    fun setNewUserName(userName: String) = itemWithResId("$packageName:id/usernameText").setText(userName)
+    fun setNewUserName(userName: String) = usernameTextInput.setText(userName)
 
     fun clickClearUserNameButton() = itemWithResId("$packageName:id/clearUsernameTextButton").click()
 
-    fun setNewPassword(password: String) = itemWithResId("$packageName:id/passwordText").setText(password)
+    fun setNewPassword(password: String) = passwordTextInput.setText(password)
 
     fun clickClearPasswordButton() = itemWithResId("$packageName:id/clearPasswordTextButton").click()
 
@@ -126,3 +177,12 @@ private fun assertSavedLoginAppears() =
         .check(matches(isDisplayed()))
 
 private val openWebsiteButton = onView(withId(R.id.openWebAddress))
+
+private val siteHeader = itemWithResId("$packageName:id/hostnameHeaderText")
+private val siteTextInput = itemWithResId("$packageName:id/hostnameText")
+private val siteDescription = itemContainingText(getStringResource(R.string.add_login_hostname_invalid_text_3))
+private val siteTextInputHint = onView(withId(R.id.hostnameText))
+private val usernameHeader = itemWithResId("$packageName:id/usernameHeader")
+private val usernameTextInput = itemWithResId("$packageName:id/usernameText")
+private val passwordHeader = itemWithResId("$packageName:id/passwordHeader")
+private val passwordTextInput = itemWithResId("$packageName:id/passwordText")


### PR DESCRIPTION
Bug 1810735 - Part 2: New logins related UI tests

Summary:
Created new UI tests to improve the "Full functional" test suite coverage:

`verifyNeverSaveLoginOptionTest` ✅ successfully passed 100x on Firebase
`verifyAutofillToggleTest` ✅ successfully passed 100x on Firebase
`verifyLoginIsNotUpdatedTest` ✅ successfully passed 100x on Firebase
`verifySearchLoginsTest` ✅ successfully passed 100x on Firebase
`verifyLastUsedLoginSortingOptionTest` ✅ successfully passed 100x on Firebase
`verifyAlphabeticalLoginSortingOptionTest` ✅ successfully passed 100x on Firebase
`verifyAddLoginManuallyTest` ✅ successfully passed 100x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
