### PR TITLE
Bug 1810818: Configures order of new user onboarding panels using a nimbus feature

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -74,6 +74,14 @@ nimbus-validation:
     settings-title:
       type: string
       description: The title of displayed in the Settings screen and app menu.
+onboarding:
+  description: "A feature that configures the new user onboarding page. Note that onboarding is a **first run** feature, and should only be modified by first run experiments."
+  hasExposure: true
+  exposureDescription: ""
+  variables:
+    order:
+      type: json
+      description: Determines the order of the onboarding page panels
 pre-permission-notification-prompt:
   description: A feature that shows the pre-permission notification prompt.
   hasExposure: true

--- a/app/src/main/java/org/mozilla/fenix/home/Mode.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/Mode.kt
@@ -13,6 +13,7 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.onboarding.FenixOnboarding
+import org.mozilla.fenix.nimbus.Onboarding as OnboardingConfig
 
 /**
  * Describes various states of the home fragment UI.
@@ -20,7 +21,7 @@ import org.mozilla.fenix.onboarding.FenixOnboarding
 sealed class Mode {
     object Normal : Mode()
     object Private : Mode()
-    data class Onboarding(val state: OnboardingState) : Mode()
+    data class Onboarding(val state: OnboardingState, val config: OnboardingConfig) : Mode()
 
     companion object {
         fun fromBrowsingMode(browsingMode: BrowsingMode) = when (browsingMode) {
@@ -55,9 +56,9 @@ class CurrentMode(
     } else {
         val account = accountManager.authenticatedAccount()
         if (account != null) {
-            Mode.Onboarding(OnboardingState.SignedIn)
+            Mode.Onboarding(OnboardingState.SignedIn, onboarding.config)
         } else {
-            Mode.Onboarding(OnboardingState.SignedOutNoAutoSignIn)
+            Mode.Onboarding(OnboardingState.SignedOutNoAutoSignIn, onboarding.config)
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/onboarding/FenixOnboarding.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/FenixOnboarding.kt
@@ -12,6 +12,7 @@ import mozilla.components.support.ktx.android.content.PreferencesHolder
 import mozilla.components.support.ktx.android.content.intPreference
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.nimbus.FxNimbus
 
 class FenixOnboarding(context: Context) : PreferencesHolder {
 
@@ -26,6 +27,15 @@ class FenixOnboarding(context: Context) : PreferencesHolder {
     }
 
     private var onboardedVersion by intPreference(LAST_VERSION_ONBOARDING_KEY, default = 0)
+
+    // The onboarding configuration is retrieved lazily because:
+    // - We do not want to record exposure if a user is not encountering onboarding
+    // - We would like to evaluate the configuration only once (and thus it's kept in memory
+    // and not re-evaluated)
+    val config by lazy {
+        FxNimbus.features.onboarding.recordExposure()
+        FxNimbus.features.onboarding.value()
+    }
 
     fun finish() {
         // New users that goes through the first run onboarding do not need to see the home

--- a/app/src/test/java/org/mozilla/fenix/home/ModeTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/ModeTest.kt
@@ -71,7 +71,7 @@ class ModeTest {
         every { onboarding.userHasBeenOnboarded() } returns false
         every { accountManager.authenticatedAccount() } returns mockk()
 
-        assertEquals(Mode.Onboarding(OnboardingState.SignedIn), currentMode.getCurrentMode())
+        assertEquals(Mode.Onboarding(OnboardingState.SignedIn, onboarding.config), currentMode.getCurrentMode())
     }
 
     @Test
@@ -80,7 +80,7 @@ class ModeTest {
         every { accountManager.authenticatedAccount() } returns null
         every { accountManager.shareableAccounts(context) } returns emptyList()
 
-        assertEquals(Mode.Onboarding(OnboardingState.SignedOutNoAutoSignIn), currentMode.getCurrentMode())
+        assertEquals(Mode.Onboarding(OnboardingState.SignedOutNoAutoSignIn, onboarding.config), currentMode.getCurrentMode())
     }
 
     @Test

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -167,6 +167,15 @@ features:
         type: Boolean
         default: true
 
+  onboarding:
+    description: "A feature that configures the new user onboarding page.
+    Note that onboarding is a **first run** feature, and should only be modified by first run experiments."
+    variables:
+      order:
+        description: Determines the order of the onboarding page panels
+        type: List<OnboardingPanel>
+        default: ["themes", "toolbar-placement", "sync", "tcp", "privacy-notice"]
+
 types:
   objects: {}
 
@@ -213,3 +222,16 @@ types:
           description: Indicates after how many hours of interaction, the dialog should show again.
         dialog-text-variant:
           description: Indicates which text variant should be used in the dialog.
+    OnboardingPanel:
+      description: The types of onboarding panels in the onboarding page
+      variants:
+        themes:
+          description: The themes onboarding panel where users pick themes
+        toolbar-placement:
+          description: The onboarding panel where users choose their toolbar placement (bottom or top)
+        sync:
+          description: The onboarding panel where users can sign in to sync
+        tcp:
+          description: The onboarding panel where users can choose their total cookie protection settings
+        privacy-notice:
+          description: The onboarding panel where users can tap to view our privacy notice.


### PR DESCRIPTION
In preparation for a new user experiment I'm planning for Firefox 111, this PR configures the onboarding flow for new users so that the order of the panels involved can be controlled using a nimbus experiment.

Added defaults that match the current order, so this PR shouldn't change any UI without an explicit experiment running.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not.
  **I'm not sure if we have existing tests, but happy to add new ones if I get guidance on where existing ones live!**
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not. It doesn't change the UI, only configures it so it can be manipulated using nimbus experiments or rollouts
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
