### PR TITLE
Bug 1815634 - Set weight and fill to text to display collection expand / collapse chevron for any length of title

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/compose/list/ExpandableListHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/list/ExpandableListHeader.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.mozilla.fenix.R
@@ -68,6 +69,8 @@ fun ExpandableListHeader(
                 color = FirefoxTheme.colors.textPrimary,
                 style = headerTextStyle,
                 maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
             )
 
             expanded?.let {


### PR DESCRIPTION
The PR fixes the bug `Collection expand/collapse chevron not displayed from a certain length of title`

### Issue Screenshots
https://user-images.githubusercontent.com/48829350/204004973-edce88a1-f94d-40d5-bb47-716f0c983110.mp4

### Fix Screenshots
https://www.loom.com/share/0599cfadc63348c29caf06257760e498

Pull Request checklist
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Screenshots: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
 
![screenshot_Firefox Fenix_2023-01-17-10_07_13](https://user-images.githubusercontent.com/2725300/212843229-48e243f2-0247-4bcf-a587-94bf812b907d.png)

**QA**
- [x] QA Needed

**GitHub Automation**
Fixes https://github.com/mozilla-mobile/fenix/issues/27974