### PR TITLE
For #1810629 - Add an Android shortcut to go straight to the login and passwords page

### DIFF
--- a/app/src/beta/res/xml/shortcuts.xml
+++ b/app/src/beta/res/xml/shortcuts.xml
@@ -4,6 +4,17 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
     <shortcut
+        android:shortcutId="password_manager"
+        android:enabled="true"
+        android:icon="@drawable/ic_static_shortcut_password_manager"
+        android:shortcutShortLabel="@string/home_screen_shortcut_open_password_screen"
+        android:shortcutLongLabel="@string/home_screen_shortcut_open_password_screen">
+        <intent
+            android:action="org.mozilla.fenix.OPEN_PASSWORD_MANAGER"
+            android:targetPackage="org.mozilla.firefox_beta"
+            android:targetClass="org.mozilla.fenix.IntentReceiverActivity" />
+    </shortcut>
+    <shortcut
         android:shortcutId="open_new_tab"
         android:enabled="true"
         android:icon="@drawable/ic_static_shortcut_tab"

--- a/app/src/debug/res/xml/shortcuts.xml
+++ b/app/src/debug/res/xml/shortcuts.xml
@@ -5,6 +5,17 @@
 
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
     <shortcut
+        android:shortcutId="password_manager"
+        android:enabled="true"
+        android:icon="@drawable/ic_static_shortcut_password_manager"
+        android:shortcutShortLabel="@string/home_screen_shortcut_open_password_screen"
+        android:shortcutLongLabel="@string/home_screen_shortcut_open_password_screen">
+        <intent
+            android:action="org.mozilla.fenix.OPEN_PASSWORD_MANAGER"
+            android:targetPackage="org.mozilla.fenix.debug"
+            android:targetClass="org.mozilla.fenix.IntentReceiverActivity" />
+    </shortcut>
+    <shortcut
         android:shortcutId="open_new_tab"
         android:enabled="true"
         android:icon="@drawable/ic_static_shortcut_tab"

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -101,6 +101,7 @@ import org.mozilla.fenix.home.intent.CrashReporterIntentProcessor
 import org.mozilla.fenix.home.intent.DefaultBrowserIntentProcessor
 import org.mozilla.fenix.home.intent.HomeDeepLinkIntentProcessor
 import org.mozilla.fenix.home.intent.OpenBrowserIntentProcessor
+import org.mozilla.fenix.home.intent.OpenPasswordManagerIntentProcessor
 import org.mozilla.fenix.home.intent.OpenSpecificTabIntentProcessor
 import org.mozilla.fenix.home.intent.SpeechProcessingIntentProcessor
 import org.mozilla.fenix.home.intent.StartSearchIntentProcessor
@@ -198,6 +199,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             OpenBrowserIntentProcessor(this, ::getIntentSessionId),
             OpenSpecificTabIntentProcessor(this),
             DefaultBrowserIntentProcessor(this),
+            OpenPasswordManagerIntentProcessor(),
         )
     }
 
@@ -1153,6 +1155,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         const val OPEN_TO_SEARCH = "open_to_search"
         const val PRIVATE_BROWSING_MODE = "private_browsing_mode"
         const val START_IN_RECENTS_SCREEN = "start_in_recents_screen"
+        const val OPEN_PASSWORD_MANAGER = "open_password_manager"
 
         // PWA must have been used within last 30 days to be considered "recently used" for the
         // telemetry purposes.

--- a/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -109,6 +109,7 @@ class IntentReceiverActivity : Activity() {
             components.intentProcessors.fennecPageShortcutIntentProcessor +
             components.intentProcessors.externalDeepLinkIntentProcessor +
             components.intentProcessors.webNotificationsIntentProcessor +
+            components.intentProcessors.passwordManagerIntentProcessor +
             modeDependentProcessors +
             NewTabShortcutIntentProcessor()
     }

--- a/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
@@ -25,6 +25,7 @@ import org.mozilla.fenix.customtabs.FennecWebAppIntentProcessor
 import org.mozilla.fenix.home.intent.FennecBookmarkShortcutsIntentProcessor
 import org.mozilla.fenix.intent.ExternalDeepLinkIntentProcessor
 import org.mozilla.fenix.perf.lazyMonitored
+import org.mozilla.fenix.shortcut.PasswordManagerIntentProcessor
 
 /**
  * Component group for miscellaneous components.
@@ -79,5 +80,9 @@ class IntentProcessors(
 
     val webNotificationsIntentProcessor by lazyMonitored {
         WebNotificationIntentProcessor(engine)
+    }
+
+    val passwordManagerIntentProcessor by lazyMonitored {
+        PasswordManagerIntentProcessor()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/intent/OpenPasswordManagerIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/OpenPasswordManagerIntentProcessor.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.intent
+
+import android.content.Intent
+import androidx.navigation.NavController
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.NavGraphDirections
+import org.mozilla.fenix.components.metrics.MetricsUtils
+import org.mozilla.fenix.ext.nav
+
+/**
+ * When the open password manager shortcut is tapped, Fenix should open to the password and login fragment.
+ */
+class OpenPasswordManagerIntentProcessor : HomeIntentProcessor {
+
+    override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
+        val event = intent.extras?.getBoolean(HomeActivity.OPEN_PASSWORD_MANAGER)
+        return if (event != null) {
+            MetricsUtils.Source.SHORTCUT
+            out.removeExtra(HomeActivity.OPEN_PASSWORD_MANAGER)
+
+            val directions = NavGraphDirections.actionGlobalSavedLoginsAuthFragment()
+            navController.nav(null, directions)
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/shortcut/PasswordManagerIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/shortcut/PasswordManagerIntentProcessor.kt
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.shortcut
+
+import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+import mozilla.components.feature.intent.processing.IntentProcessor
+import mozilla.components.support.utils.SafeIntent
+import org.mozilla.fenix.HomeActivity
+
+/**
+ * PasswordManagerIntentProcessor is responsible for processing intents that are related to the password manager.
+ */
+class PasswordManagerIntentProcessor : IntentProcessor {
+
+    /**
+     * Processes the given [Intent].
+     *
+     * @param intent The intent to process.
+     * @return True if the intent was processed, otherwise false.
+     */
+    override fun process(intent: Intent): Boolean {
+        val safeIntent = SafeIntent(intent)
+
+        if (!safeIntent.action.equals(ACTION_OPEN_PASSWORD_MANAGER)) {
+            return false
+        }
+
+        intent.putExtra(HomeActivity.OPEN_PASSWORD_MANAGER, true)
+        intent.flags = intent.flags or FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
+        return true
+    }
+
+    companion object {
+        const val ACTION_OPEN_PASSWORD_MANAGER = "org.mozilla.fenix.OPEN_PASSWORD_MANAGER"
+    }
+}

--- a/app/src/main/res/drawable-v26/ic_static_shortcut_password_manager.xml
+++ b/app/src/main/res/drawable-v26/ic_static_shortcut_password_manager.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/static_shortcut_background"/>
+    <foreground android:drawable="@drawable/ic_static_lock"/>
+</adaptive-icon>

--- a/app/src/main/res/drawable/ic_static_lock.xml
+++ b/app/src/main/res/drawable/ic_static_lock.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="108dp"
+    android:width="108dp"
+    android:tint="#312A65"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+    <path android:fillColor="@android:color/white"
+        android:pathData="M15,10h-0.5L14.5,9c0,-1.38 -1.12,-2.5 -2.5,-2.5S9.5,7.62 9.5,9v1L9,10c-0.55,0 -1,0.45 -1,1v5c0,0.55 0.45,1 1,1h6c0.55,0 1,-0.45 1,-1L16,11c0,-0.55 -0.45,-1 -1,-1zM10.5,9c0,-0.83 0.67,-1.5 1.5,-1.5s1.5,0.67 1.5,1.5v1L10.5,10L10.5,9zM15,16L9,16L9,11h6v5zM12,14.5c0.55,0 1,-0.45 1,-1s-0.45,-1 -1,-1 -1,0.45 -1,1 0.45,1 1,1z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_static_shortcut_password_manager.xml
+++ b/app/src/main/res/drawable/ic_static_shortcut_password_manager.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_static_shortcut_background" />
+    <item android:drawable="@drawable/ic_static_lock" />
+</layer-list>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,8 @@
     <string name="home_screen_shortcut_open_new_tab_2">New tab</string>
     <!-- Shortcut action to open new private tab -->
     <string name="home_screen_shortcut_open_new_private_tab_2">New private tab</string>
+    <!-- Shortcut action to open Passwords screens -->
+    <string name="home_screen_shortcut_open_password_screen">Password manager</string>
 
     <!-- Recent Tabs -->
     <!-- Header text for jumping back into the recent tab in the home screen -->

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -5,6 +5,17 @@
 
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
     <shortcut
+        android:shortcutId="password_manager"
+        android:enabled="true"
+        android:icon="@drawable/ic_static_shortcut_password_manager"
+        android:shortcutShortLabel="@string/home_screen_shortcut_open_password_screen"
+        android:shortcutLongLabel="@string/home_screen_shortcut_open_password_screen">
+        <intent
+            android:action="org.mozilla.fenix.OPEN_PASSWORD_MANAGER"
+            android:targetPackage="org.mozilla.fenix"
+            android:targetClass="org.mozilla.fenix.IntentReceiverActivity" />
+    </shortcut>
+    <shortcut
         android:shortcutId="open_new_tab"
         android:enabled="true"
         android:icon="@drawable/ic_static_shortcut_tab"

--- a/app/src/nightly/res/xml/shortcuts.xml
+++ b/app/src/nightly/res/xml/shortcuts.xml
@@ -5,6 +5,17 @@
 
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
     <shortcut
+        android:shortcutId="password_manager"
+        android:enabled="true"
+        android:icon="@drawable/ic_static_shortcut_password_manager"
+        android:shortcutShortLabel="@string/home_screen_shortcut_open_password_screen"
+        android:shortcutLongLabel="@string/home_screen_shortcut_open_password_screen">
+        <intent
+            android:action="org.mozilla.fenix.OPEN_PASSWORD_MANAGER"
+            android:targetPackage="org.mozilla.fenix"
+            android:targetClass="org.mozilla.fenix.IntentReceiverActivity" />
+    </shortcut>
+    <shortcut
         android:shortcutId="open_new_tab"
         android:enabled="true"
         android:icon="@drawable/ic_static_shortcut_tab"

--- a/app/src/release/res/xml/shortcuts.xml
+++ b/app/src/release/res/xml/shortcuts.xml
@@ -4,6 +4,17 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
     <shortcut
+        android:shortcutId="password_manager"
+        android:enabled="true"
+        android:icon="@drawable/ic_static_shortcut_password_manager"
+        android:shortcutShortLabel="@string/home_screen_shortcut_open_password_screen"
+        android:shortcutLongLabel="@string/home_screen_shortcut_open_password_screen">
+        <intent
+            android:action="org.mozilla.fenix.OPEN_PASSWORD_MANAGER"
+            android:targetPackage="org.mozilla.firefox"
+            android:targetClass="org.mozilla.fenix.IntentReceiverActivity" />
+    </shortcut>
+    <shortcut
         android:shortcutId="open_new_tab"
         android:enabled="true"
         android:icon="@drawable/ic_static_shortcut_tab"

--- a/app/src/test/java/org/mozilla/fenix/IntentReceiverActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/IntentReceiverActivityTest.kt
@@ -40,6 +40,7 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.helpers.perf.TestStrictModeManager
 import org.mozilla.fenix.shortcut.NewTabShortcutIntentProcessor
+import org.mozilla.fenix.shortcut.PasswordManagerIntentProcessor
 import org.mozilla.fenix.utils.Settings
 import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
@@ -68,6 +69,7 @@ class IntentReceiverActivityTest {
         every { intentProcessors.fennecPageShortcutIntentProcessor } returns mockIntentProcessor()
         every { intentProcessors.externalDeepLinkIntentProcessor } returns mockIntentProcessor()
         every { intentProcessors.webNotificationsIntentProcessor } returns mockIntentProcessor()
+        every { intentProcessors.passwordManagerIntentProcessor } returns mockIntentProcessor()
 
         coEvery { intentProcessors.intentProcessor.process(any()) } returns true
     }
@@ -263,6 +265,21 @@ class IntentReceiverActivityTest {
 
         verify { intentProcessors.webNotificationsIntentProcessor.process(intent) }
         verify { activity.launch(intent, IntentProcessorType.NEW_TAB) }
+    }
+
+    @Test
+    fun `process intent with action OPEN_PASSWORD_MANAGER`() = runTest {
+        val intent = Intent()
+        intent.action = PasswordManagerIntentProcessor.ACTION_OPEN_PASSWORD_MANAGER
+
+        val activity = Robolectric.buildActivity(IntentReceiverActivity::class.java, intent).get()
+        attachMocks(activity)
+        activity.processIntent(intent)
+
+        val shadow = shadowOf(activity)
+        val actualIntent = shadow.peekNextStartedActivity()
+
+        assertEquals(HomeActivity::class.java.name, actualIntent.component?.className)
     }
 
     private fun attachMocks(activity: Activity) {

--- a/app/src/test/java/org/mozilla/fenix/home/intent/OpenPasswordManagerIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/OpenPasswordManagerIntentProcessorTest.kt
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.intent
+
+import android.content.Intent
+import androidx.navigation.NavController
+import io.mockk.Called
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.NavGraphDirections
+import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.shortcut.PasswordManagerIntentProcessor
+
+@RunWith(FenixRobolectricTestRunner::class)
+class OpenPasswordManagerIntentProcessorTest {
+
+    private lateinit var activity: HomeActivity
+    private lateinit var navController: NavController
+    private lateinit var out: Intent
+    private lateinit var processor: OpenPasswordManagerIntentProcessor
+
+    @Before
+    fun setup() {
+        activity = mockk(relaxed = true)
+        navController = mockk(relaxed = true)
+        out = mockk(relaxed = true)
+        processor = OpenPasswordManagerIntentProcessor()
+    }
+
+    @Test
+    fun `GIVEN a blank intent WHEN it is processed THEN nothing should happen`() {
+        assertFalse(processor.process(Intent(), navController, out))
+
+        verify { activity wasNot Called }
+        verify { navController wasNot Called }
+        verify { out wasNot Called }
+    }
+
+    @Test
+    fun `GIVEN an intent with wrong action WHEN it is processed THEN nothing should happen`() {
+        val intent = Intent().apply {
+            action = TEST_WRONG_ACTION
+        }
+
+        assertFalse(processor.process(intent, navController, out))
+
+        verify { activity wasNot Called }
+        verify { navController wasNot Called }
+        verify { out wasNot Called }
+    }
+
+    @Test
+    fun `GIVEN an intent with correct action and extra boolean WHEN it is processed THEN navigate should be called`() {
+        val intent = Intent().apply {
+            action = PasswordManagerIntentProcessor.Companion.ACTION_OPEN_PASSWORD_MANAGER
+            putExtra(HomeActivity.OPEN_PASSWORD_MANAGER, true)
+        }
+
+        assertTrue(processor.process(intent, navController, out))
+
+        verify { navController.nav(null, NavGraphDirections.actionGlobalSavedLoginsAuthFragment()) }
+        verify { out.removeExtra(HomeActivity.OPEN_PASSWORD_MANAGER) }
+    }
+
+    companion object {
+        const val TEST_WRONG_ACTION = "test-action"
+    }
+}


### PR DESCRIPTION
The PR creates a shortcut that users can place on the HomeScreen and when the user clicks the shortcut it will open the `login and passwords page`

### Issue Screenshots
No video this is a new feature not bug

### Fix Screenshots
https://www.loom.com/share/ed2452528b754822afee436b3dca64f8

Pull Request checklist
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Screenshots: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
 
**QA**
- [x] QA Needed

**GitHub Automation**
Fixes [#1810629](https://bugzilla.mozilla.org/show_bug.cgi?id=1810629) 