### PR TITLE
Bug 1811045 - Expand device and scheduling for legacy Android testing cron

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -37,5 +37,7 @@ jobs:
           treeherder-symbol: legacy-api-ui
           target-tasks-method: legacy_api_ui_tests
       when:
-          - {hour: 11, minute: 0}
-          - {hour: 20, minute: 0}
+          - {hour: 9, minute: 0}
+          - {hour: 12, minute: 0}
+          - {hour: 18, minute: 0}
+          - {hour: 22, minute: 0}

--- a/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
+++ b/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
@@ -47,6 +47,15 @@ gcloud:
     - model: dreamlte
       version: 28
       locale: en_US
+    - model: HWANE-LX2
+      version: 28
+      locale: en_US
+    - model: HWCOR
+      version: 27
+      locale: en_US
+    - model: blueline
+      version: 28
+      locale: en_US
 
 flank:
   project: GOOGLE_PROJECT


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1811045