### PR TITLE
Bug 1811673: No landscape support for "Allow notifications" screen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/onboarding/HomeNotificationPermissionDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/HomeNotificationPermissionDialogFragment.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.onboarding
 
-import android.annotation.SuppressLint
 import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -24,11 +23,9 @@ import org.mozilla.fenix.theme.FirefoxTheme
  */
 class HomeNotificationPermissionDialogFragment : DialogFragment() {
 
-    @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setStyle(STYLE_NO_TITLE, R.style.HomeOnboardingDialogStyle)
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product. 

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.



https://user-images.githubusercontent.com/39155305/213867210-f0641fa5-1ef1-4e26-89c5-cc510c346c51.mp4


![Screenshot_20230121_181157_Accessibility Scanner](https://user-images.githubusercontent.com/39155305/213867343-6dfaf7fb-6a9a-44e2-94d6-aa779e39649e.jpg)
