### PR TITLE
For #27169 - Increased `Search engine` button height from home screen.

### DIFF
--- a/app/src/main/res/drawable/search_pill_background.xml
+++ b/app/src/main/res/drawable/search_pill_background.xml
@@ -12,7 +12,7 @@
                 android:width="1dp"
                 android:color="?accentBright" />
 
-            <corners android:radius="16dp" />
+            <corners android:radius="24dp" />
         </shape>
     </item>
 </layer-list>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -93,7 +93,7 @@
     <dimen name="search_fragment_clipboard_item_height">56dp</dimen>
     <dimen name="search_fragment_clipboard_item_horizontal_margin">8dp</dimen>
     <dimen name="search_fragment_clipboard_item_title_margin_start">8dp</dimen>
-    <dimen name="search_fragment_pill_height">40dp</dimen>
+    <dimen name="search_fragment_pill_height">48dp</dimen>
     <dimen name="search_fragment_pill_padding_start">20dp</dimen>
     <dimen name="search_fragment_pill_padding_end">16dp</dimen>
     <dimen name="search_fragment_pill_padding_vertical">4dp</dimen>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -380,7 +380,7 @@
 
     <style name="search_pill" parent="Widget.AppCompat.Button.Borderless">
         <item name="android:layout_width">wrap_content</item>
-        <item name="android:layout_height">40dp</item>
+        <item name="android:layout_height">48dp</item>
         <item name="android:paddingTop">4dp</item>
         <item name="android:paddingBottom">4dp</item>
         <item name="android:textAllCaps">false</item>


### PR DESCRIPTION
The PR fixes the issue of Accessibility scanner app suggesting the height of the `search engine` item be increased

### Issue Screenshots
![fnx-issue](https://user-images.githubusercontent.com/93866435/213650322-2e51674c-cbd1-4c66-8de4-9a6a2e0db273.png)
### Fix Screenshots
![fnx-fix](https://user-images.githubusercontent.com/93866435/213650372-0cfe20fc-c2f7-43cc-ab41-5f815e7a0f53.png)

Pull Request checklist
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Screenshots: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
 
**QA**
- [x] QA Needed

**GitHub Automation**
Fixes https://github.com/mozilla-mobile/fenix/issues/27169