### PR TITLE
Bug 1812178 - Use debounce in tabs, history and bookmarks syncs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeature.kt
@@ -73,6 +73,7 @@ class RecentSyncedTabFeature(
                     accountManager.withConstellation { refreshDevices() }
                     accountManager.syncNow(
                         reason = SyncReason.User,
+                        debounce = true,
                         customEngineSubset = listOf(SyncEngine.Tabs),
                     )
                 }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
@@ -18,6 +18,7 @@ import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.sync.SyncReason
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
@@ -223,7 +224,11 @@ class DefaultBookmarkController(
     override fun handleRequestSync() {
         scope.launch {
             store.dispatch(BookmarkFragmentAction.StartSync)
-            activity.components.backgroundServices.accountManager.syncNow(SyncReason.User)
+            activity.components.backgroundServices.accountManager.syncNow(
+                reason = SyncReason.User,
+                debounce = true,
+                customEngineSubset = listOf(SyncEngine.Bookmarks),
+            )
             // The current bookmark node we are viewing may be made invalid after syncing so we
             // check if the current node is valid and if it isn't we find the nearest valid ancestor
             // and open it

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.launch
 import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.lib.state.ext.flowScoped
+import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.sync.SyncReason
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.ktx.kotlin.toShortUrl
@@ -368,7 +369,11 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler, 
     @Suppress("UnusedPrivateMember")
     private suspend fun syncHistory() {
         val accountManager = requireComponents.backgroundServices.accountManager
-        accountManager.syncNow(SyncReason.User)
+        accountManager.syncNow(
+            reason = SyncReason.User,
+            debounce = true,
+            customEngineSubset = listOf(SyncEngine.History),
+        )
         historyView.historyAdapter.refresh()
     }
 

--- a/app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeatureTest.kt
@@ -140,7 +140,7 @@ class RecentSyncedTabFeatureTest {
 
         verify { appStore.dispatch(AppAction.RecentSyncedTabStateChange(RecentSyncedTabState.Loading)) }
         coVerify { accountManager.withConstellation { refreshDevices() } }
-        coVerify { accountManager.syncNow(reason = SyncReason.User, customEngineSubset = listOf(SyncEngine.Tabs)) }
+        coVerify { accountManager.syncNow(reason = SyncReason.User, debounce = true, customEngineSubset = listOf(SyncEngine.Tabs)) }
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
