### PR TITLE
Bug 1807298 - re-enable deleteAllSearchEnginesTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -9,6 +9,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
@@ -17,6 +18,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.appContext
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
+import org.mozilla.fenix.helpers.TestHelper.runWithCondition
 import org.mozilla.fenix.helpers.TestHelper.setTextToClipBoard
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
@@ -376,7 +378,6 @@ class SettingsSearchTest {
         }
     }
 
-    @Ignore("Test failure caused by: https://bugzilla.mozilla.org/show_bug.cgi?id=1807298")
     // Expected for en-us defaults
     @Test
     fun deleteAllSearchEnginesTest() {
@@ -384,23 +385,46 @@ class SettingsSearchTest {
         }.openThreeDotMenu {
         }.openSettings {
         }.openSearchSubMenu {
-            deleteMultipleSearchEngines(
-                "Google",
-                "Bing",
-                "Amazon.com",
-                "DuckDuckGo",
-                "eBay",
-            )
-            verifyDefaultSearchEngine("Wikipedia")
-            verifyThreeDotButtonIsNotDisplayed("Wikipedia")
-            openAddSearchEngineMenu()
-            verifyAddSearchEngineListContains(
-                "Google",
-                "Bing",
-                "Amazon.com",
-                "DuckDuckGo",
-                "eBay",
-            )
+            runWithCondition(!appContext.settings().showUnifiedSearchFeature) {
+                // If the feature is disabled run old steps.
+                deleteMultipleSearchEngines(
+                    "Google",
+                    "Bing",
+                    "Amazon.com",
+                    "DuckDuckGo",
+                    "eBay",
+                )
+                verifyDefaultSearchEngine("Wikipedia")
+                verifyThreeDotButtonIsNotDisplayed("Wikipedia")
+                openAddSearchEngineMenu()
+                verifyAddSearchEngineListContains(
+                    "Google",
+                    "Bing",
+                    "Amazon.com",
+                    "DuckDuckGo",
+                    "eBay",
+                )
+            }
+            runWithCondition(appContext.settings().showUnifiedSearchFeature) {
+                // Run steps suitable for the enabled unified search feature.
+                deleteMultipleSearchEngines(
+                    "Google",
+                    "Bing",
+                    "Amazon.com",
+                    "eBay",
+                    "Wikipedia",
+                )
+                verifyDefaultSearchEngine("DuckDuckGo")
+                verifyThreeDotButtonIsNotDisplayed("DuckDuckGo")
+                openAddSearchEngineMenu()
+                verifyAddSearchEngineListContains(
+                    "Google",
+                    "Bing",
+                    "Amazon.com",
+                    "eBay",
+                    "Wikipedia",
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Bug 1807298 - re-enable `deleteAllSearchEnginesTest` UI test ✅ successfully passed 50x on Firebase.

When unified search will be enabled by default, `deleteMultipleSearchEngines` will fail when trying to delete DuckDuckGo.
It will automatically select DuckDuckGo (the last general search engine in the list) which will not have the ⋮ more options button displayed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
