### PR TITLE
Bug 1815633 - Set margin top to zero when address bar is set to not to hide on scroll which removes a blank space on installed pwa

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -1052,7 +1052,7 @@ abstract class BaseBrowserFragment :
             if (context.settings().shouldUseBottomToolbar) {
                 swipeRefreshParams.bottomMargin = toolbarHeight
             } else {
-                swipeRefreshParams.topMargin = toolbarHeight
+                swipeRefreshParams.topMargin = 0
             }
         }
     }


### PR DESCRIPTION
The PR fixes a blank space on installed PWA when the address bar is set not to hide on scroll.

### Fix description
Remove the margin-top

### Issue Screenshot
![image](https://user-images.githubusercontent.com/2725300/213976692-e1de6267-c1d1-46fc-9b51-c189e5bcd07e.png)

### Fix Screenshot
![Screenshot_20230123-122243](https://user-images.githubusercontent.com/2725300/214016903-a3e36cfa-101f-4531-9ad8-f19c05043bb5.png)


### Pull Request checklist
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots:** This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

**QA**
- [x] QA Needed
### To download an APK when reviewing a PR (after all CI tasks finished running):

1. Click on Checks at the top of the PR page.
2. Click on the firefoxci-taskcluster group on the left to expand all tasks.
3. Click on the build-debug task.
4. Click on View task in Taskcluster in the new DETAILS section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #28378