### PR TITLE
For #27179 - Added minimum height and width property to URL icon and adjusted view accordingly.

### DIFF
--- a/app/src/main/res/layout/library_site_item.xml
+++ b/app/src/main/res/layout/library_site_item.xml
@@ -29,8 +29,10 @@
                 tools:src="@drawable/ic_folder_icon" />
         <ImageView
                 android:id="@+id/checkmark"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginStart="4dp"
+                android:layout_marginTop="4dp"
                 android:padding="10dp"
                 android:background="@drawable/favicon_background"
                 android:backgroundTint="?accent"
@@ -78,6 +80,8 @@
             android:id="@+id/overflow_menu"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
             android:background="?android:attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/content_description_menu"
             app:srcCompat="@drawable/ic_menu"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -13,7 +13,7 @@
     <dimen name="mozac_browser_menu2_corner_radius">8dp</dimen>
     <dimen name="library_item_height">56dp</dimen>
     <dimen name="library_item_icon_margin_horizontal">16dp</dimen>
-    <dimen name="history_favicon_width_height">40dp</dimen>
+    <dimen name="history_favicon_width_height">48dp</dimen>
     <dimen name="tab_corner_radius">8dp</dimen>
     <dimen name="preference_icon_drawable_size">24dp</dimen>
     <dimen name="search_bar_search_engine_icon_padding">12dp</dimen>


### PR DESCRIPTION
The PR fixes an accessibility issue that is related to URL icon size on history page.

### Fix description
Added minimum height and width property to `48dp` to icon and adjusted view accordingly.

### Issue video
https://www.loom.com/share/5a3d65c270224baba9ade032eb8238fe

### Demo video after fix
https://www.loom.com/share/768c3ae6fcbc4f79b0ee2fb4b1caf3f7

### Pull Request checklist
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots:** This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

**QA**
- [x] QA Needed
### To download an APK when reviewing a PR (after all CI tasks finished running):

1. Click on Checks at the top of the PR page.
2. Click on the firefoxci-taskcluster group on the left to expand all tasks.
3. Click on the build-debug task.
4. Click on View task in Taskcluster in the new DETAILS section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #27179