### PR TITLE
Bug 1812829: Instead of hardcoding button height, set it as minimum of height range

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/compose/button/Button.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/button/Button.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.ButtonDefaults
@@ -48,7 +48,7 @@ private fun Button(
         onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
-            .height(36.dp),
+            .heightIn(min = 36.dp),
         elevation = ButtonDefaults.elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
         colors = ButtonDefaults.outlinedButtonColors(
             backgroundColor = backgroundColor,


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

View in small font size (unchanged)
![Screenshot_20230127_153005_Firefox Fenix](https://user-images.githubusercontent.com/39155305/215062771-654dad8a-e8fb-430e-b67e-394e0618f6b8.jpg)

Updated view in large font size (height expands)
![Screenshot_20230127_152944_Firefox Fenix](https://user-images.githubusercontent.com/39155305/215062782-082895d7-f814-411b-931f-c320b71553d6.jpg)

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
