### PR TITLE
Bug 1812627 - Add FirefoxTheme to ProfilerDialogueCard

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/perf/ProfilerReusableComposable.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/ProfilerReusableComposable.kt
@@ -35,11 +35,13 @@ import org.mozilla.fenix.theme.FirefoxTheme
  */
 @Composable
 fun ProfilerDialogueCard(content: @Composable () -> Unit) {
-    Card(
-        elevation = 8.dp,
-        shape = RoundedCornerShape(12.dp),
-    ) {
-        content()
+    FirefoxTheme {
+        Card(
+            elevation = 8.dp,
+            shape = RoundedCornerShape(12.dp),
+        ) {
+            content()
+        }
     }
 }
 


### PR DESCRIPTION
Crash was occurring on the ProfilerDialogueStartFragment because FirefoxTheme wasn't applied to the ProfilerDialogueCard but the RadioButton was looking for FirefoxTheme to apply default colors.

https://bugzilla.mozilla.org/show_bug.cgi?id=1812627

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
