### PR TITLE
Bug 1812580 - Re-enable collections related ui tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
@@ -94,7 +94,6 @@ class CollectionTest {
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1812580")
     @SmokeTest
     @Test
     fun verifyExpandedCollectionItemsTest() {
@@ -144,7 +143,6 @@ class CollectionTest {
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1813058")
     @SmokeTest
     @Test
     fun openAllTabsInCollectionTest() {
@@ -177,7 +175,6 @@ class CollectionTest {
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1812580")
     @SmokeTest
     @Test
     fun shareCollectionTest() {
@@ -206,7 +203,6 @@ class CollectionTest {
 
     // Test running on beta/release builds in CI:
     // caution when making changes to it, so they don't block the builds
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1812580")
     @SmokeTest
     @Test
     fun deleteCollectionTest() {
@@ -232,7 +228,6 @@ class CollectionTest {
     }
 
     // open a webpage, and add currently opened tab to existing collection
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1812580")
     @Test
     fun mainMenuSaveToExistingCollection() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
@@ -259,7 +254,6 @@ class CollectionTest {
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1812580")
     @Test
     fun verifyAddTabButtonOfCollectionMenu() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
@@ -286,7 +280,6 @@ class CollectionTest {
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1813048")
     @Test
     fun renameCollectionTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
@@ -307,7 +300,6 @@ class CollectionTest {
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1812580")
     @Test
     fun createSecondCollectionTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
@@ -330,7 +322,6 @@ class CollectionTest {
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1812580")
     @Test
     fun removeTabFromCollectionTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
@@ -353,7 +344,6 @@ class CollectionTest {
         }
     }
 
-    @Ignore("Failing, see: Bugzilla tickets 1807289 and 1812997")
     @Test
     fun swipeLeftToRemoveTabFromCollectionTest() {
         val testPage = getGenericAsset(mockWebServer, 1)
@@ -380,7 +370,6 @@ class CollectionTest {
         }
     }
 
-    @Ignore("Failing, see: Bugzilla tickets 1807289 and 1813047")
     @Test
     fun swipeRightToRemoveTabFromCollectionTest() {
         val testPage = getGenericAsset(mockWebServer, 1)

--- a/app/src/main/java/org/mozilla/fenix/components/FenixSnackbarBehavior.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FenixSnackbarBehavior.kt
@@ -60,18 +60,20 @@ class FenixSnackbarBehavior<V : View>(
         currentAnchorId = dependency?.id ?: View.NO_ID
         val params = snackbar.layoutParams as CoordinatorLayout.LayoutParams
 
-        if (dependency == null || (dependency.id == R.id.toolbar && toolbarPosition == ToolbarPosition.TOP)) {
-            // Position the snackbar at the bottom of the screen.
-            params.anchorId = View.NO_ID
-            params.anchorGravity = Gravity.NO_GRAVITY
-            params.gravity = Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
-        } else {
-            // Position the snackbar just above the anchor.
-            params.anchorId = dependency.id
-            params.anchorGravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
-            params.gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+        snackbar.post {
+            if (dependency == null || (dependency.id == R.id.toolbar && toolbarPosition == ToolbarPosition.TOP)) {
+                // Position the snackbar at the bottom of the screen.
+                params.anchorId = View.NO_ID
+                params.anchorGravity = Gravity.NO_GRAVITY
+                params.gravity = Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
+                snackbar.layoutParams = params
+            } else {
+                // Position the snackbar just above the anchor.
+                params.anchorId = dependency.id
+                params.anchorGravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+                params.gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+                snackbar.layoutParams = params
+            }
         }
-
-        snackbar.layoutParams = params
     }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
