### PR TITLE
For 1811532 - Add secret setting allowing to overwrite the site parameter for Pocket sponsored stories

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -212,6 +212,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
     private val startupPathProvider = StartupPathProvider()
     private lateinit var startupTypeTelemetry: StartupTypeTelemetry
 
+    @Suppress("ComplexMethod")
     final override fun onCreate(savedInstanceState: Bundle?) {
         // DO NOT MOVE ANYTHING ABOVE THIS getProfilerTime CALL.
         val startTimeProfiler = components.core.engine.profiler?.getProfilerTime()
@@ -330,6 +331,11 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             }
             if (settings().showPocketSponsoredStories) {
                 components.core.pocketStoriesService.startPeriodicSponsoredStoriesRefresh()
+                // If the secret setting for sponsored stories parameters is set,
+                // force refresh the sponsored Pocket stories.
+                if (settings().useCustomConfigurationForSponsoredStories) {
+                    components.core.pocketStoriesService.refreshSponsoredStories()
+                }
             }
         }
 

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -72,6 +72,7 @@ import mozilla.components.service.digitalassetlinks.local.StatementRelationCheck
 import mozilla.components.service.location.LocationService
 import mozilla.components.service.location.MozillaLocationService
 import mozilla.components.service.pocket.PocketStoriesConfig
+import mozilla.components.service.pocket.PocketStoriesRequestConfig
 import mozilla.components.service.pocket.PocketStoriesService
 import mozilla.components.service.pocket.Profile
 import mozilla.components.service.sync.autofill.AutofillCreditCardsAddressesStorage
@@ -411,6 +412,11 @@ class Core(
                 profileId = UUID.fromString(context.settings().pocketSponsoredStoriesProfileId),
                 appId = BuildConfig.POCKET_CONSUMER_KEY,
             ),
+            sponsoredStoriesParams = if (context.settings().useCustomConfigurationForSponsoredStories) {
+                PocketStoriesRequestConfig(context.settings().pocketSponsoredStoriesSiteId)
+            } else {
+                PocketStoriesRequestConfig()
+            },
         )
     }
     val pocketStoriesService by lazyMonitored { PocketStoriesService(context, pocketStoriesConfig) }

--- a/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.settings
 
 import android.os.Bundle
+import androidx.navigation.fragment.findNavController
 import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -14,6 +15,7 @@ import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 
@@ -61,5 +63,20 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
         requirePreference<EditTextPreference>(R.string.pref_key_custom_glean_server_url).apply {
             isVisible = Config.channel.isNightlyOrDebug && BuildConfig.GLEAN_CUSTOM_URL.isNullOrEmpty()
         }
+
+        requirePreference<Preference>(R.string.pref_key_custom_sponsored_stories_parameters).apply {
+            isVisible = Config.channel.isNightlyOrDebug
+        }
+    }
+
+    override fun onPreferenceTreeClick(preference: Preference?): Boolean {
+        when (preference?.key) {
+            getString(R.string.pref_key_custom_sponsored_stories_parameters) ->
+                findNavController().nav(
+                    R.id.secretSettingsPreference,
+                    SecretSettingsFragmentDirections.actionSecretSettingsFragmentToSponsoredStoriesSettings(),
+                )
+        }
+        return super.onPreferenceTreeClick(preference)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/SponsoredStoriesSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SponsoredStoriesSettingsFragment.kt
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import android.os.Bundle
+import androidx.preference.EditTextPreference
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreference
+import org.mozilla.fenix.Config
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.settings
+
+/**
+ * Allows customizing sponsored stories fetch parameters.
+ */
+class SponsoredStoriesSettingsFragment : PreferenceFragmentCompat() {
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.sponsored_stories_settings, rootKey)
+
+        requirePreference<SwitchPreference>(R.string.pref_key_custom_sponsored_stories_parameters_enabled).apply {
+            isVisible = Config.channel.isNightlyOrDebug
+            isChecked = context.settings().useCustomConfigurationForSponsoredStories
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
+        requirePreference<EditTextPreference>(R.string.pref_key_custom_sponsored_stories_site_id).apply {
+            isVisible = Config.channel.isNightlyOrDebug
+            onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+                context.settings().pocketSponsoredStoriesSiteId = (newValue as String)
+                true
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1457,6 +1457,22 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
+     *  Whether or not to display the Pocket sponsored stories parameter secret settings.
+     */
+    var useCustomConfigurationForSponsoredStories by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_custom_sponsored_stories_parameters_enabled),
+        default = false,
+    )
+
+    /**
+     * Site parameter used to set the spoc content.
+     */
+    var pocketSponsoredStoriesSiteId by stringPreference(
+        appContext.getPreferenceKey(R.string.pref_key_custom_sponsored_stories_site_id),
+        default = "",
+    )
+
+    /**
      * Indicates if the Contile functionality should be visible.
      */
     var showContileFeature by booleanPreference(

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -817,7 +817,15 @@
     <fragment
         android:id="@+id/secretSettingsPreference"
         android:name="org.mozilla.fenix.settings.SecretSettingsFragment"
-        android:label="@string/preferences_debug_settings" />
+        android:label="@string/preferences_debug_settings">
+        <action
+            android:id="@+id/action_secretSettingsFragment_to_sponsoredStoriesSettings"
+            app:destination="@id/sponsoredStoriesSettings"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
+    </fragment>
     <fragment
         android:id="@+id/secretInfoSettingsFragment"
         android:name="org.mozilla.fenix.settings.SecretDebugSettingsFragment"
@@ -842,6 +850,10 @@
         android:id="@+id/cookieBannerFragment"
         android:name="org.mozilla.fenix.settings.CookieBannersFragment"
         android:label="@string/preferences_cookie_banner_reduction" />
+    <fragment
+        android:id="@+id/sponsoredStoriesSettings"
+        android:name="org.mozilla.fenix.settings.SponsoredStoriesSettingsFragment"
+        android:label="@string/preferences_debug_settings_custom_sponsored_stories_parameters" />
     <fragment
         android:id="@+id/trackingProtectionFragment"
         android:name="org.mozilla.fenix.settings.TrackingProtectionFragment">

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -317,6 +317,9 @@
     <string name="pref_key_history_metadata_feature" translatable="false">pref_key_history_metadata_feature</string>
     <string name="pref_key_show_unified_search" translatable="false">pref_key_show_unified_search</string>
     <string name="pref_key_custom_glean_server_url" translatable="false">pref_key_custom_glean_server_url</string>
+    <string name="pref_key_custom_sponsored_stories_parameters" translatable="false">pref_key_custom_sponsored_stories_parameters</string>
+    <string name="pref_key_custom_sponsored_stories_parameters_enabled" translatable="false">pref_key_custom_sponsored_stories_parameters_enabled</string>
+    <string name="pref_key_custom_sponsored_stories_site_id" translatable="false">pref_key_custom_sponsored_stories_site_id</string>
 
     <!-- Growth Data -->
     <string name="pref_key_growth_set_as_default" translatable="false">pref_key_growth_set_as_default</string>

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -48,6 +48,12 @@
     <string name="preferences_debug_settings_unified_search" translatable="false">Enable Unified Search (requires restart)</string>
     <!-- Label for custom Glean server URL -->
     <string name="preferences_debug_settings_custom_glean_server_url" translatable="false">Custom Glean server URL (requires restart)</string>
+    <!-- Label for custom Pocket sponsored stories settings -->
+    <string name="preferences_debug_settings_custom_sponsored_stories_parameters" translatable="false">Pocket sponsored stories</string>
+    <!-- Label for custom Pocket sponsored stories site enabled setting -->
+    <string name="preferences_debug_settings_custom_sponsored_stories_parameters_enabled" translatable="false">Enable custom Pocket sponsored stories parameters (requires restart)</string>
+    <!-- Label for custom Pocket sponsored stories site id setting -->
+    <string name="preferences_debug_settings_custom_sponsored_stories_parameters_site" translatable="false">Site parameter</string>
     <!-- Title of preference for sync debugging (only shown in the when the secret debug menu is enabled) -->
     <string name="preferences_sync_debug">Sync Debug</string>
     <!-- Preference to override the Push server -->

--- a/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/app/src/main/res/xml/secret_settings_preferences.xml
@@ -31,4 +31,9 @@
         android:inputType="textUri"
         app:useSimpleSummaryProvider="true"
         app:iconSpaceReserved="false" />
+    <Preference
+        android:key="@string/pref_key_custom_sponsored_stories_parameters"
+        app:iconSpaceReserved="false"
+        android:title="@string/preferences_debug_settings_custom_sponsored_stories_parameters"
+        />
 </PreferenceScreen>

--- a/app/src/main/res/xml/sponsored_stories_settings.xml
+++ b/app/src/main/res/xml/sponsored_stories_settings.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/pref_key_custom_sponsored_stories_parameters_enabled"
+        android:title="@string/preferences_debug_settings_custom_sponsored_stories_parameters_enabled"
+        app:iconSpaceReserved="false" />
+    <EditTextPreference
+        android:dependency="@string/pref_key_custom_sponsored_stories_parameters_enabled"
+        android:inputType="text"
+        android:key="@string/pref_key_custom_sponsored_stories_site_id"
+        android:title="@string/preferences_debug_settings_custom_sponsored_stories_parameters_site"
+        app:iconSpaceReserved="false"
+        app:useSimpleSummaryProvider="true" />
+</androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Added secret setting allowing to overwrite the `site` parameter for Pocket sponsored stories. When the `site` secret setting is set, restarting the app force refreshes the local sponsored stories, to avoid having users who might be interested in testing Pocket sponsored stories wait for the scheduled worker refresh (currently set to 4 hours).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
