### PR TITLE
Bug 1807293 - remove SDK suppression on audioVideoPermissionChoiceOnEachRequestTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SitePermissionsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SitePermissionsTest.kt
@@ -8,9 +8,7 @@ import android.Manifest
 import android.content.Context
 import android.hardware.camera2.CameraManager
 import android.media.AudioManager
-import android.os.Build
 import androidx.core.net.toUri
-import androidx.test.filters.SdkSuppress
 import androidx.test.rule.GrantPermissionRule
 import org.junit.Assume.assumeTrue
 import org.junit.Rule
@@ -55,7 +53,6 @@ class SitePermissionsTest {
     @get: Rule
     val retryTestRule = RetryTestRule(3)
 
-    @SdkSuppress(maxSdkVersion = Build.VERSION_CODES.P, codeName = "P")
     @SmokeTest
     @Test
     fun audioVideoPermissionChoiceOnEachRequestTest() {


### PR DESCRIPTION
Removed the SDK suppression tag and re-ran the test on API 30 100 times, all green: https://github.com/mozilla-mobile/fenix/runs/10975957295

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
