### PR TITLE
Bug 1807272 - fix flaky dismissOnboardingWithPageLoadTest UI test 

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/OnboardingTest.kt
@@ -138,12 +138,12 @@ class OnboardingTest {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         homeScreen {
-            verifyWelcomeHeader()
+            verifyStartBrowsingButton()
         }
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.goToHomescreen {
-            verifyExistingTopSitesList()
+            verifyHomeScreen()
         }
     }
 


### PR DESCRIPTION
Bug 1807272 - fix flaky `dismissOnboardingWithPageLoadTest` UI test ✅ successfully passed 100x on Firebase.

Summary:
When exiting to the home screen sometimes the home screen is automatically scrolled to the bottom, so I've changed the verification from `verifyExistingTopSitesList` to `verifyHomeScreen` due to a bug [1813567](https://bugzilla.mozilla.org/show_bug.cgi?id=1813567)
And in some cases the onboarding is slightly scrolled, so I've switched from `verifyWelcomeHeader` to `verifyStartBrowsingButton`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
