### PR TITLE
For #28216 - Added a menu item to open current page in a new private tab

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
@@ -358,6 +358,17 @@ class DefaultBrowserToolbarMenuController(
                     BrowserFragmentDirections.actionGlobalHome(focusOnAddressBar = true),
                 )
             }
+
+            is ToolbarMenu.Item.OpenInPrivate -> {
+                store.state.selectedTab.let {
+                    getProperUrl(it)?.let { sessionUrl ->
+                        navController.navigate(
+                            BrowserFragmentDirections.actionGlobalHome(openInPrivate = true, url = sessionUrl),
+                        )
+                    }
+                }
+            }
+
             is ToolbarMenu.Item.SetDefaultBrowser -> {
                 activity.openSetDefaultBrowserOption()
             }
@@ -459,6 +470,8 @@ class DefaultBrowserToolbarMenuController(
                 Events.browserMenuAction.record(Events.BrowserMenuActionExtra("set_default_browser"))
             is ToolbarMenu.Item.RemoveFromTopSites ->
                 Events.browserMenuAction.record(Events.BrowserMenuActionExtra("remove_from_top_sites"))
+            is ToolbarMenu.Item.OpenInPrivate ->
+                Events.browserMenuAction.record(Events.BrowserMenuActionExtra("open_in_private"))
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -202,6 +202,14 @@ open class DefaultToolbarMenu(
         onItemTapped.invoke(ToolbarMenu.Item.NewTab)
     }
 
+    private val openInPrivateItem = BrowserMenuImageText(
+        context.getString(R.string.library_open_in_private_mode),
+        R.drawable.private_browsing_button,
+        primaryTextColor(),
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.OpenInPrivate)
+    }
+
     private val historyItem = BrowserMenuImageText(
         context.getString(R.string.library_history),
         R.drawable.ic_history,
@@ -364,6 +372,7 @@ open class DefaultToolbarMenu(
             listOfNotNull(
                 if (shouldUseBottomToolbar) null else menuToolbar,
                 newTabItem,
+                if (selectedSession?.content?.private == false) openInPrivateItem else null,
                 BrowserMenuDivider(),
                 bookmarksItem,
                 historyItem,

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
@@ -9,6 +9,7 @@ import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
 import org.mozilla.fenix.components.accounts.AccountState
 
 interface ToolbarMenu {
+    @Suppress("UndocumentedPublicClass")
     sealed class Item {
         object Settings : Item()
         data class RequestDesktop(val isChecked: Boolean) : Item()
@@ -35,6 +36,7 @@ interface ToolbarMenu {
         object History : Item()
         object Downloads : Item()
         object NewTab : Item()
+        object OpenInPrivate : Item()
     }
 
     val menuBuilder: BrowserMenuBuilder

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -77,6 +77,7 @@ import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.HomeScreen
@@ -627,6 +628,20 @@ class HomeFragment : Fragment() {
                     linearLayoutManager.startSmoothScroll(smoothScroller)
                 }
             }
+        } else if (bundleArgs.getBoolean(OPEN_IN_PRIVATE) &&
+            !bundleArgs.getString(SESSION_URL).isNullOrEmpty()
+        ) {
+            sessionControlInteractor.onOpenInPrivateClicked(
+                bundleArgs.getString(SESSION_URL).toString(),
+            )
+
+            removeTabAndShowSnackbar(store.state.selectedTabId.toString())
+
+            (activity as HomeActivity).openToBrowserAndLoad(
+                searchTermOrURL = bundleArgs.getString(SESSION_URL).toString(),
+                newTab = store.state.selectedTabId == null,
+                from = BrowserDirection.FromHome,
+            )
         }
 
         consumeFlow(requireComponents.core.store) { flow ->
@@ -1077,6 +1092,8 @@ class HomeFragment : Fragment() {
         const val ALL_PRIVATE_TABS = "all_private"
 
         private const val FOCUS_ON_ADDRESS_BAR = "focusOnAddressBar"
+        private const val OPEN_IN_PRIVATE = "openInPrivate"
+        private const val SESSION_URL = "url"
 
         private const val SCROLL_TO_COLLECTION = "scrollToCollection"
         private const val ANIM_SCROLL_DELAY = 100L

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -193,6 +193,11 @@ interface SessionControlController {
     fun handlePrivateModeButtonClicked(newMode: BrowsingMode, userHasBeenOnboarded: Boolean)
 
     /**
+     * @see [TabSessionInteractor.onOpenInPrivateClicked]
+     */
+    fun handleOpenInPrivateClicked(sessionUrl: String)
+
+    /**
      * @see [CustomizeHomeIteractor.openCustomizeHomePage]
      */
     fun handleCustomizeHomeTapped()
@@ -625,6 +630,17 @@ class DefaultSessionControlController(
         if (userHasBeenOnboarded) {
             appStore.dispatch(
                 AppAction.ModeChange(Mode.fromBrowsingMode(newMode)),
+            )
+        }
+    }
+
+    override fun handleOpenInPrivateClicked(sessionUrl: String) {
+        with(activity) {
+            browsingModeManager.mode = BrowsingMode.Private
+            openToBrowserAndLoad(
+                searchTermOrURL = sessionUrl,
+                newTab = true,
+                from = BrowserDirection.FromHome,
             )
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -52,6 +52,11 @@ interface TabSessionInteractor {
      * * @param state The state the homepage from which to report desired metrics.
      */
     fun reportSessionMetrics(state: AppState)
+
+    /**
+     * Called when a user clicks open in Private.
+     */
+    fun onOpenInPrivateClicked(sessionUrl: String)
 }
 
 /**
@@ -445,6 +450,10 @@ class SessionControlInteractor(
 
     override fun reportSessionMetrics(state: AppState) {
         controller.handleReportSessionMetrics(state)
+    }
+
+    override fun onOpenInPrivateClicked(sessionUrl: String) {
+        controller.handleOpenInPrivateClicked(sessionUrl)
     }
 
     override fun onMessageClicked(message: Message) {

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -195,6 +195,15 @@
             android:name="scrollToCollection"
             android:defaultValue="false"
             app:argType="boolean" />
+        <argument
+            android:name="openInPrivate"
+            android:defaultValue="false"
+            app:argType="boolean" />
+        <argument
+            android:name="url"
+            app:argType="string"
+            android:defaultValue=""
+            app:nullable="true" />
     </fragment>
     <dialog
         android:id="@+id/homeOnboardingDialogFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -682,6 +682,8 @@
     <string name="library_history">History</string>
     <!-- Option in Library to open a new tab -->
     <string name="library_new_tab">New tab</string>
+    <!-- Option in Library to open in private mode -->
+    <string name="library_open_in_private_mode">Open in Private</string>
     <!-- Settings Page Title -->
     <string name="settings_title">Settings</string>
     <!-- Content description (not visible, for screen readers etc.): "Close button for library settings" -->

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
@@ -771,6 +771,28 @@ class DefaultBrowserToolbarMenuControllerTest {
     }
 
     @Test
+    fun `WHEN Open In Private menu item is pressed THEN navigate to a private tab`() = runTest {
+        val item = ToolbarMenu.Item.OpenInPrivate
+        val url = "https://www.mozilla.org"
+
+        val controller = createController(scope = this, store = browserStore)
+
+        controller.handleToolbarItemInteraction(item)
+
+        verify {
+            navController.navigate(
+                directionsEq(
+                    NavGraphDirections.actionGlobalHome(
+                        focusOnAddressBar = false,
+                        openInPrivate = true,
+                        url = url,
+                    ),
+                ),
+            )
+        }
+    }
+
+    @Test
     fun `GIVEN account exists and the user is signed in WHEN sign in to sync menu item is pressed THEN navigate to account settings`() = runTest {
         val item = ToolbarMenu.Item.SyncAccount(AccountState.AUTHENTICATED)
         val accountSettingsDirections = BrowserFragmentDirections.actionGlobalAccountSettingsFragment()

--- a/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -1122,6 +1122,32 @@ class DefaultSessionControlControllerTest {
     }
 
     @Test
+    fun `WHEN open in private is selected from a normal window THEN handle opening new tab`() {
+        every { navController.currentDestination } returns mockk {
+            every { id } returns R.id.searchDialogFragment
+        }
+
+        val url = "https://mozilla.org"
+        val tab = createTab(
+            id = "otherTab",
+            url = url,
+            private = true,
+            engineSession = mockk(relaxed = true),
+        )
+        store.dispatch(TabListAction.AddTabAction(tab, select = true)).joinBlocking()
+
+        createController().handleOpenInPrivateClicked(url)
+
+        verify {
+            activity.openToBrowserAndLoad(
+                searchTermOrURL = url,
+                newTab = true,
+                from = BrowserDirection.FromHome,
+            )
+        }
+    }
+
+    @Test
     fun `WHEN handleReportSessionMetrics is called AND there are zero recent tabs THEN report Event#RecentTabsSectionIsNotVisible`() {
         assertNull(RecentTabs.sectionVisible.testGetValue())
 

--- a/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -201,6 +201,14 @@ class SessionControlInteractorTest {
     }
 
     @Test
+    fun `WHEN open in private is clicked THEN the click is handled`() {
+        val url = "https://mozilla.org"
+
+        interactor.onOpenInPrivateClicked(url)
+        verify { controller.handleOpenInPrivateClicked(sessionUrl = url) }
+    }
+
+    @Test
     fun `WHEN onSettingsClicked is called THEN handleTopSiteSettingsClicked is called`() {
         interactor.onSettingsClicked()
         verify { controller.handleTopSiteSettingsClicked() }


### PR DESCRIPTION
The PR implement the feature where user can open a `current tab` in a `private window`

### Issue Screenshots
User can not currently open a current tab in a private window 

### Fix Screenshots
https://www.loom.com/share/3dccdf2514a14689b5b22671d93cf030

Pull Request checklist
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Screenshots: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
 
**QA**
- [x] QA Needed

**GitHub Automation**
Fixes https://github.com/mozilla-mobile/fenix/issues/28216