### PR TITLE
For #27881 - Increased the `x` button height and margin in the `Username` field on the `Add New Login` page

### DIFF
--- a/app/src/main/res/layout/fragment_add_login.xml
+++ b/app/src/main/res/layout/fragment_add_login.xml
@@ -144,15 +144,15 @@
     <ImageButton
         android:id="@+id/clearUsernameTextButton"
         android:layout_width="48dp"
-        android:layout_height="30dp"
-        android:layout_marginTop="3dp"
-        android:layout_marginBottom="10dp"
+        android:layout_height="48dp"
+        android:layout_marginBottom="18dp"
         android:background="@null"
         android:contentDescription="@string/saved_login_clear_username"
         android:visibility="invisible"
         app:tint="@color/saved_login_clear_edit_text_tint"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/inputLayoutUsername"
+        app:layout_constraintBottom_toBottomOf="@+id/inputLayoutUsername"
         app:srcCompat="@drawable/mozac_ic_clear" />
 
     <TextView
@@ -180,7 +180,6 @@
         android:colorControlActivated="?attr/textPrimary"
         android:colorControlHighlight="?attr/textPrimary"
         android:contentDescription="@string/saved_login_password_description"
-        android:paddingBottom="11dp"
         android:textColor="?attr/textPrimary"
         app:hintEnabled="false"
         app:layout_constraintEnd_toEndOf="@id/passwordHeader"
@@ -215,13 +214,13 @@
     <ImageButton
         android:id="@+id/clearPasswordTextButton"
         android:layout_width="48dp"
-        android:layout_height="30dp"
-        android:layout_marginTop="3dp"
-        android:layout_marginBottom="10dp"
+        android:layout_height="48dp"
+        android:layout_marginBottom="18dp"
         android:background="@null"
         android:contentDescription="@string/saved_logins_clear_password"
         android:visibility="invisible"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@+id/inputLayoutPassword"
         app:layout_constraintTop_toTopOf="@id/inputLayoutPassword"
         app:srcCompat="@drawable/mozac_ic_clear"
         app:tint="@color/saved_login_clear_edit_text_tint" />


### PR DESCRIPTION
This PR fixes 'Consider increasing the "x" button in the "Username" field on the "Add New Login" page'

### Fix description
Added height to be 48dp and added a margin-bottom of 18 dp  for both username and password x button

### Issue video
https://www.loom.com/share/11925d0c67ac4a138eb9c4fd266b014c

### Demo video after fix
https://www.loom.com/share/77013aa4710f4814a6e5f63da9ea753a


### Pull Request checklist
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots:** This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

**QA**
- [x] QA Needed
### To download an APK when reviewing a PR (after all CI tasks finished running):

1. Click on Checks at the top of the PR page.
2. Click on the firefoxci-taskcluster group on the left to expand all tasks.
3. Click on the build-debug task.
4. Click on View task in Taskcluster in the new DETAILS section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #27881