### PR TITLE
For #28226 - Add top padding to the Home App Bar

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -643,6 +643,7 @@ class HomeFragment : Fragment() {
             profilerStartTime,
             "HomeFragment.onViewCreated",
         )
+        homeAppBarPadding()
     }
 
     private fun updateSearchSelectorMenu(searchEngines: List<SearchEngine>) {
@@ -882,6 +883,20 @@ class HomeFragment : Fragment() {
         // Counterpart to the update in onResume to keep the last access timestamp of the selected
         // tab up-to-date.
         requireComponents.useCases.sessionUseCases.updateLastAccess()
+    }
+
+    // Add padding to the homeAppBar when the toolbar position is set to top
+    private fun homeAppBarPadding() {
+        val settings = context?.components?.settings
+        when (settings?.toolbarPosition) {
+            ToolbarPosition.TOP -> {
+                binding.homeAppBar.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                    topMargin =
+                        resources.getDimensionPixelSize(R.dimen.home_fragment_top_appbar_header_margin)
+                }
+            }
+            else -> {}
+        }
     }
 
     @SuppressLint("InflateParams")

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -77,6 +77,7 @@
 
     <!-- Home Fragment -->
     <dimen name="home_fragment_top_toolbar_header_margin">60dp</dimen>
+    <dimen name="home_fragment_top_appbar_header_margin">90dp</dimen>
     <dimen name="home_item_horizontal_margin">16dp</dimen>
     <dimen name="home_item_vertical_margin">8dp</dimen>
     <dimen name="wordmark_text_height">18dp</dimen>


### PR DESCRIPTION
The PR fixes the issue where  `the incognito button` hides behind the  `Fill from clipboard` dialog when you have something in your clipboard

### Issue Screenshots
[fnxoss-issue.webm](https://user-images.githubusercontent.com/93866435/212933262-42e20632-487d-4843-a6b4-d9090fd3fe3b.webm)

### Fix Screenshots
[fnxoss-fix.webm](https://user-images.githubusercontent.com/93866435/213145017-20bedfd7-369d-4487-bca5-12315647f2f6.webm)


Pull Request checklist
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Screenshots: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
 
**QA**
- [x] QA Needed

**GitHub Automation**
Fixes https://github.com/mozilla-mobile/fenix/issues/28226
Fixes #28226
Fixes #28226