### PR TITLE
Bug 1806798 - Make download filename scrollable.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/downloads/StartDownloadDialog.kt
+++ b/app/src/main/java/org/mozilla/fenix/downloads/StartDownloadDialog.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.downloads
 
 import android.app.Activity
 import android.app.Dialog
+import android.text.method.ScrollingMovementMethod
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
@@ -186,6 +187,7 @@ class FirstPartyDownloadDialog(
         }
 
         dialog.filename.text = filename
+        dialog.filename.movementMethod = ScrollingMovementMethod()
 
         dialog.downloadButton.setOnClickListener {
             positiveButtonAction()

--- a/app/src/main/res/layout/start_download_dialog_layout.xml
+++ b/app/src/main/res/layout/start_download_dialog_layout.xml
@@ -69,9 +69,11 @@
         android:layout_marginStart="3dp"
         android:layout_marginTop="16dp"
         android:layout_toEndOf="@id/icon"
+        android:maxHeight="160dp"
         android:paddingStart="5dp"
         android:paddingTop="4dp"
         android:paddingEnd="5dp"
+        android:scrollbars="vertical"
         android:textColor="?android:attr/textColorPrimary"
         tools:text="@tools:sample/lorem/random"
         tools:textColor="#000000" />

--- a/app/src/test/java/org/mozilla/fenix/downloads/FirstPartyDownloadDialogTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/downloads/FirstPartyDownloadDialogTest.kt
@@ -64,7 +64,7 @@ class FirstPartyDownloadDialogTest {
             ),
             dialogBinding.title.text,
         )
-        assertEquals("Test", dialogBinding.filename.text)
+        assertEquals("Test", dialogBinding.filename.text.toString())
         assertFalse(wasPositiveActionDone)
         assertFalse(wasNegativeActionDone)
         dialogBinding.downloadButton.callOnClick()
@@ -102,7 +102,7 @@ class FirstPartyDownloadDialogTest {
             testContext.getString(R.string.mozac_feature_downloads_dialog_download),
             dialogBinding.title.text,
         )
-        assertEquals("Test", dialogBinding.filename.text)
+        assertEquals("Test", dialogBinding.filename.text.toString())
         assertFalse(wasPositiveActionDone)
         assertFalse(wasNegativeActionDone)
         dialogBinding.downloadButton.callOnClick()


### PR DESCRIPTION
Also add a max height for the file name, so the download button is always visible.

Video with results:

https://user-images.githubusercontent.com/48995920/215766724-3bef22ef-8fa7-4696-9f65-820ff2e2e424.mp4

Note that it is the same fix approved by UX for AC download dialog (Still used in Focus) as here: https://github.com/mozilla-mobile/firefox-android/pull/527

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
