### PR TITLE
Bug 1814082 - Part 2: New address autofill related UI tests

### DIFF
--- a/app/src/androidTest/assets/pages/addressForm.html
+++ b/app/src/androidTest/assets/pages/addressForm.html
@@ -5,12 +5,13 @@
 </head>
 <body>
     <form>
-    <p>Street Address: <input id="streetAddress" type="text"></p>
-    <p>City: <input id="city" type="text"></p>
-    <p>Zip Code: <input id="zipCode" type="text"></p>
-    <p>Country: <input id="country" type="text"></p>
-    <p>Telephone: <input id="telephone" type="text"></p>
-    <p>Email: <input id="email" type="text"></p>
+        <p>Street Address: <input id="streetAddress" type="text"></p>
+        <p>City: <input id="city" type="text"></p>
+        <p>Zip Code: <input id="zipCode" type="text"></p>
+        <p>Country: <input id="country" type="text"></p>
+        <p>Telephone: <input id="telephone" type="text"></p>
+        <p>Email: <input id="email" type="text"></p>
+        <p>Apartment, suite, etc. <input id="apartment" type="text"></p>
     </form>
 </body>
 </html>

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/AddressAutofillTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/AddressAutofillTest.kt
@@ -366,4 +366,41 @@ class AddressAutofillTest {
             verifyManuallyFilledAddress("Ap. 07")
         }
     }
+
+    @Test
+    fun verifyAutofillAddressSectionTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openAutofillSubMenu {
+            verifyAddressAutofillSection(true, false)
+            clickAddAddressButton()
+            fillAndSaveAddress(
+                "Mozilla",
+                "Fenix",
+                "Firefox",
+                "Harrison Street",
+                "San Francisco",
+                "Alaska",
+                "94105",
+                "United States",
+                "555-5555",
+                "foo@bar.com",
+            )
+            verifyAddressAutofillSection(true, true)
+            clickManageAddressesButton()
+            verifyManageAddressesSection(
+                "Mozilla",
+                "Fenix",
+                "Firefox",
+                "Harrison Street",
+                "San Francisco",
+                "Alaska",
+                "94105",
+                "US",
+                "555-5555",
+                "foo@bar.com",
+            )
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/AddressAutofillTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/AddressAutofillTest.kt
@@ -329,4 +329,41 @@ class AddressAutofillTest {
             verifyStateOption("Alberta")
         }
     }
+
+    @Test
+    fun verifyFormFieldCanBeFilledManuallyTest() {
+        val addressFormPage =
+            TestAssetHelper.getAddressFormAsset(mockWebServer)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openAutofillSubMenu {
+            clickAddAddressButton()
+            fillAndSaveAddress(
+                "Mozilla",
+                "Fenix",
+                "Firefox",
+                "Harrison Street",
+                "San Francisco",
+                "Alaska",
+                "94105",
+                "United States",
+                "555-5555",
+                "foo@bar.com",
+            )
+        }
+
+        exitMenu()
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(addressFormPage.url) {
+            clickStreetAddressTextBox()
+            clickSelectAddressButton()
+            clickAddressSuggestion("Harrison Street")
+            verifyAutofilledAddress("Harrison Street")
+            setTextForApartmentTextBox("Ap. 07")
+            verifyManuallyFilledAddress("Ap. 07")
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/AddressAutofillTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/AddressAutofillTest.kt
@@ -275,4 +275,42 @@ class AddressAutofillTest {
             verifyAutofilledAddress("Fort Street")
         }
     }
+
+    @Test
+    fun verifySavedAddressCanBeEditedTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openAutofillSubMenu {
+            verifyAddressAutofillSection(true, false)
+            clickAddAddressButton()
+            fillAndSaveAddress(
+                "Mozilla",
+                "Fenix",
+                "Firefox",
+                "Harrison Street",
+                "San Francisco",
+                "Alaska",
+                "94105",
+                "United States",
+                "555-5555",
+                "foo@bar.com",
+            )
+            clickManageAddressesButton()
+            clickSavedAddress("Mozilla")
+            fillAndSaveAddress(
+                "Android",
+                "Test",
+                "Name",
+                "Fort Street",
+                "San Jose",
+                "Arizona",
+                "95141",
+                "United States",
+                "777-7777",
+                "fuu@bar.org",
+            )
+            verifyManageAddressesToolbarTitle()
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/AddressAutofillTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/AddressAutofillTest.kt
@@ -313,4 +313,20 @@ class AddressAutofillTest {
             verifyManageAddressesToolbarTitle()
         }
     }
+
+    @Test
+    fun verifyStateFieldUpdatesInAccordanceWithCountryFieldTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openAutofillSubMenu {
+            verifyAddressAutofillSection(true, false)
+            clickAddAddressButton()
+            verifyCountryOption("United States")
+            verifyStateOption("Alabama")
+            verifyCountryOptions("Canada", "United States")
+            clickCountryOption("Canada")
+            verifyStateOption("Alberta")
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -524,6 +524,9 @@ class BrowserRobot {
 
     fun clickStreetAddressTextBox() = clickPageObject(webPageItemWithResourceId("streetAddress"))
 
+    fun setTextForApartmentTextBox(apartment: String) =
+        webPageItemWithResourceId("apartment").setText(apartment)
+
     fun clearAddressForm() {
         webPageItemWithResourceId("streetAddress").clearTextField()
         webPageItemWithResourceId("city").clearTextField()
@@ -620,6 +623,14 @@ class BrowserRobot {
         mDevice.waitForObjects(webPageItemContainingTextAndResourceId("streetAddress", streetAddress))
         assertTrue(
             webPageItemContainingTextAndResourceId("streetAddress", streetAddress)
+                .waitForExists(waitingTime),
+        )
+    }
+
+    fun verifyManuallyFilledAddress(apartment: String) {
+        mDevice.waitForObjects(webPageItemContainingTextAndResourceId("apartment", apartment))
+        assertTrue(
+            webPageItemContainingTextAndResourceId("apartment", apartment)
                 .waitForExists(waitingTime),
         )
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAutofillRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAutofillRobot.kt
@@ -208,21 +208,20 @@ class SettingsSubMenuAutofillRobot {
         emailAddress: String,
     ) {
         firstNameTextInput.waitForExists(waitingTime)
+        mDevice.pressBack()
         firstNameTextInput.setText(firstName)
         middleNameTextInput.setText(middleName)
         lastNameTextInput.setText(lastName)
         streetAddressTextInput.setText(streetAddress)
-        scrollToElementByText(getStringResource(R.string.addresses_city))
         cityTextInput.setText(city)
         subRegionDropDown.click()
         clickSubRegionOption(state)
         zipCodeTextInput.setText(zipCode)
         countryDropDown.click()
         clickCountryOption(country)
-        scrollToElementByText(getStringResource(R.string.addresses_phone))
+        scrollToElementByText(getStringResource(R.string.addresses_save_button))
         phoneTextInput.setText(phoneNumber)
         emailTextInput.setText(emailAddress)
-        scrollToElementByText(getStringResource(R.string.addresses_save_button))
         saveButton.click()
         manageAddressesButton.waitForExists(waitingTime)
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAutofillRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAutofillRobot.kt
@@ -116,6 +116,27 @@ class SettingsSubMenuAutofillRobot {
         )
     }
 
+    fun verifyCountryOption(country: String) {
+        scrollToElementByText(getStringResource(R.string.addresses_country))
+        mDevice.pressBack()
+        assertItemContainingTextExists(itemContainingText(country))
+    }
+
+    fun verifyStateOption(state: String) =
+        assertItemContainingTextExists(itemContainingText(state))
+
+    fun verifyCountryOptions(vararg countries: String) {
+        countryDropDown.click()
+        for (country in countries) {
+            assertItemContainingTextExists(itemContainingText(country))
+        }
+    }
+
+    fun selectCountry(country: String) {
+        countryDropDown.click()
+        countryOption(country).click()
+    }
+
     fun verifyEditAddressView() {
         assertItemContainingTextExists(editAddressToolbarTitle)
         assertItemWithDescriptionExists(navigateBackButton)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAutofillRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAutofillRobot.kt
@@ -162,8 +162,11 @@ class SettingsSubMenuAutofillRobot {
     fun clickConfirmDeleteAddressButton() = confirmDeleteAddressButton.click()
 
     fun clickSubRegionOption(subRegion: String) {
-        subRegionOption(subRegion).waitForExists(waitingTime)
-        subRegionOption(subRegion).click()
+        scrollToElementByText(subRegion)
+        subRegionOption(subRegion).also {
+            it.waitForExists(waitingTime)
+            it.click()
+        }
     }
     fun clickCountryOption(country: String) {
         countryOption(country).waitForExists(waitingTime)


### PR DESCRIPTION
Bug 1814082 - Part 2: New address autofill related UI tests

Created new UI tests to improve the "Full functional" test suite coverage.
`verifySavedAddressCanBeEditedTest` ✅ successfully passed 100x on Firebase
`verifyStateFieldUpdatesInAccordanceWithCountryFieldTest` ✅ successfully passed 100x on Firebase
`verifyFormFieldCanBeFilledManuallyTest` ✅ successfully passed 100x on Firebase
`verifyAutofillAddressSectionTest` ✅ successfully passed 100x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
