### PR TITLE
Bug 1814283 - re-enable app link related UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
@@ -63,7 +63,6 @@ class PwaTest {
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1814283")
     @SmokeTest
     @Test
     fun telephoneLinkPWATest() {
@@ -76,6 +75,7 @@ class PwaTest {
             clickAddAutomaticallyButton()
         }.openHomeScreenShortcut(shortcutTitle) {
             clickLinkMatchingText("Telephone link")
+            clickOpenInAppPromptButton()
             assertNativeAppOpens(PHONE_APP, phoneLink)
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/WebControlsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/WebControlsTest.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.ui
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -164,7 +163,6 @@ class WebControlsTest {
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1814283")
     @Test
     fun emailLinkTest() {
         val externalLinksPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
@@ -172,11 +170,11 @@ class WebControlsTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(externalLinksPage.url) {
             clickLinkMatchingText("Email link")
+            clickOpenInAppPromptButton()
             assertNativeAppOpens(Constants.PackageName.GMAIL_APP, emailLink)
         }
     }
 
-    @Ignore("Failing, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1814283")
     @Test
     fun telephoneLinkTest() {
         val externalLinksPage = TestAssetHelper.getExternalLinksAsset(mockWebServer)
@@ -184,6 +182,7 @@ class WebControlsTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(externalLinksPage.url) {
             clickLinkMatchingText("Telephone link")
+            clickOpenInAppPromptButton()
             assertNativeAppOpens(Constants.PackageName.PHONE_APP, phoneLink)
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -47,6 +47,7 @@ import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
 import org.mozilla.fenix.helpers.MatcherHelper
 import org.mozilla.fenix.helpers.MatcherHelper.assertItemWithResIdExists
 import org.mozilla.fenix.helpers.MatcherHelper.itemWithResId
+import org.mozilla.fenix.helpers.MatcherHelper.itemWithResIdAndText
 import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
@@ -946,6 +947,13 @@ class BrowserRobot {
             it.waitForExists(waitingTime)
             it.click()
         }
+
+    fun clickOpenInAppPromptButton() =
+        itemWithResIdAndText("android:id/button1", "OPEN")
+            .also {
+                it.waitForExists(waitingTime)
+                it.click()
+            }
 
     class Transition {
         private fun threeDotButton() = onView(


### PR DESCRIPTION
Bug 1814283 - re-enable app link related UI tests.
All 3 UI tests successfully passed 100x on Firebase ✅ 

Summary:
The tests were disabled because an "open in app" prompt was recently added.
I've added an extra step in our tests, namely, click `clickOpenInAppPromptButton`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
