### PR TITLE
Closes #7861: position text based on layout direction, not text directionality

### DIFF
--- a/app/src/main/res/layout/about_list_item.xml
+++ b/app/src/main/res/layout/about_list_item.xml
@@ -17,6 +17,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:gravity="center"
+        android:textAlignment="center"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/component_downloads.xml
+++ b/app/src/main/res/layout/component_downloads.xml
@@ -26,6 +26,7 @@
         android:layout_height="0dp"
         android:gravity="center"
         android:text="@string/download_empty_message_1"
+        android:textAlignment="center"
         android:textColor="?attr/textSecondary"
         android:textSize="16sp"
         android:visibility="gone"

--- a/app/src/main/res/layout/component_history.xml
+++ b/app/src/main/res/layout/component_history.xml
@@ -40,6 +40,7 @@
         android:layout_height="0dp"
         android:gravity="center"
         android:text="@string/history_empty_message"
+        android:textAlignment="center"
         android:textColor="?attr/textSecondary"
         android:textSize="16sp"
         android:visibility="gone"

--- a/app/src/main/res/layout/component_history_metadata_group.xml
+++ b/app/src/main/res/layout/component_history_metadata_group.xml
@@ -14,6 +14,7 @@
         android:layout_height="0dp"
         android:gravity="center"
         android:text="@string/history_empty_message"
+        android:textAlignment="center"
         android:textColor="?attr/textSecondary"
         android:textSize="16sp"
         android:visibility="gone"

--- a/app/src/main/res/layout/fragment_add_ons_management.xml
+++ b/app/src/main/res/layout/fragment_add_ons_management.xml
@@ -33,12 +33,13 @@
         android:id="@+id/add_ons_empty_message"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="4dp"
         android:layout_gravity="center"
         android:gravity="center"
+        android:padding="4dp"
         android:text="@string/no_add_ons"
+        android:textAlignment="center"
         android:textColor="?attr/textSecondary"
         android:textSize="16sp"
-        android:visibility="gone"/>
+        android:visibility="gone" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_site_permissions_exceptions.xml
+++ b/app/src/main/res/layout/fragment_site_permissions_exceptions.xml
@@ -37,6 +37,7 @@
         android:layout_height="0dp"
         android:gravity="center"
         android:text="@string/no_site_exceptions"
+        android:textAlignment="center"
         android:textColor="?attr/textPrimary"
         android:textSize="20sp"
         android:visibility="gone"

--- a/app/src/main/res/layout/fragment_turn_on_sync.xml
+++ b/app/src/main/res/layout/fragment_turn_on_sync.xml
@@ -21,6 +21,7 @@
             android:layout_height="wrap_content"
             android:gravity="center"
             android:text="@string/sign_in_with_camera"
+            android:textAlignment="center"
             android:textAppearance="@style/Header16TextStyle"
             android:textColor="?attr/textPrimary"
             android:textSize="20sp"
@@ -47,12 +48,13 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:gravity="center"
-            tools:text="@string/sign_in_instructions"
+            android:textAlignment="center"
             android:textColor="?attr/textPrimary"
             android:textSize="16sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/sign_in_image" />
+            app:layout_constraintTop_toBottomOf="@+id/sign_in_image"
+            tools:text="@string/sign_in_instructions" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/signInScanButton"
@@ -78,13 +80,14 @@
             android:id="@+id/createAccount"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginVertical="24dp"
             android:gravity="center"
+            android:textAlignment="center"
             android:textAppearance="@style/Body14TextStyle"
-            app:layout_constraintTop_toBottomOf="@id/signInEmailButton"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            android:layout_marginVertical="24dp"
-            tools:text="@string/sign_in_create_account_text"/>
+            app:layout_constraintTop_toBottomOf="@id/signInEmailButton"
+            tools:text="@string/sign_in_create_account_text" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/normal_browser_tray_list.xml
+++ b/app/src/main/res/layout/normal_browser_tray_list.xml
@@ -17,9 +17,9 @@
         android:layout_height="match_parent"
         android:focusable="true"
         android:focusableInTouchMode="true"
-        android:gravity="center_horizontal"
         android:paddingTop="80dp"
         android:text="@string/no_open_tabs_description"
+        android:textAlignment="center"
         android:textColor="?attr/textSecondary"
         android:textSize="16sp"
         android:visibility="visible" />

--- a/app/src/main/res/layout/private_browser_tray_list.xml
+++ b/app/src/main/res/layout/private_browser_tray_list.xml
@@ -17,9 +17,9 @@
         android:layout_height="match_parent"
         android:focusable="true"
         android:focusableInTouchMode="true"
-        android:gravity="center_horizontal"
         android:paddingTop="80dp"
         android:text="@string/no_open_tabs_description"
+        android:textAlignment="center"
         android:textColor="?attr/textSecondary"
         android:textSize="16sp"
         android:visibility="visible" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,6 +8,7 @@
         <!-- Android system styling -->
         <item name="searchViewStyle">@style/SearchViewStyle</item>
         <item name="autoCompleteTextViewStyle">@style/AutoCompleteTextViewStyle</item>
+        <item name="android:textAlignment">viewStart</item>
         <item name="android:windowContentTransitions">true</item>
         <item name="android:windowAnimationStyle">@style/WindowAnimationTransition</item>
         <item name="android:progressBarStyleHorizontal">@style/progressBarStyleHorizontal</item>
@@ -209,6 +210,7 @@
         <!-- Android system styling -->
         <item name="searchViewStyle">@style/SearchViewStyle</item>
         <item name="autoCompleteTextViewStyle">@style/AutoCompleteTextViewStyle</item>
+        <item name="android:textAlignment">viewStart</item>
         <item name="android:windowContentTransitions">true</item>
         <item name="android:windowAnimationStyle">@style/WindowAnimationTransition</item>
         <item name="android:progressBarStyleHorizontal">@style/progressBarStyleHorizontal</item>


### PR DESCRIPTION
Getting back to the RTL [PR](https://github.com/mozilla-mobile/fenix/pull/28340) that caused [regression](https://github.com/mozilla-mobile/fenix/issues/28550) and was [reverted](https://github.com/mozilla-mobile/fenix/pull/28568).

We use `android:textAlignment="viewStart"` already in many text views in the app, but not in every `textView`, which makes the UI inconsistent for RTL locales. Setting supporting RTL text alignment in styles does look like the right way of doing it. 

The problem that the first PR caused: `android:textAlignment` overrides horizontal gravity. Views that had manually set `gravity` (center, center_horizontal) got broken because of that. 

I tried to change the layouts as little as possible, adding the `cener` `textAlignment` for the textViews that want the text to be in the middle while having `0width`.

As a follow up, I will remove manually set `android:textAlignment="viewStart"` in textViews, since the code is duplicated.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #7861