### PR TITLE
For #27822 - Refractor code to toggle the save button to active when fields are properly set.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.google.android.material.textfield.TextInputLayout
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.ktx.android.view.hideKeyboard
@@ -154,6 +155,25 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login), MenuProvider {
         binding.usernameText.addTextChangedListener(
             object : TextWatcher {
                 override fun afterTextChanged(u: Editable?) {
+                    when {
+                        u.toString().isEmpty() -> {
+                            validUsername = false
+                            binding.clearUsernameTextButton.isVisible = false
+                            setLayoutError(
+                                context?.getString(R.string.saved_login_username_required),
+                                binding.inputLayoutUsername,
+                            )
+                        }
+
+                        else -> {
+                            validUsername = true
+                            binding.inputLayoutUsername.error = null
+                            binding.inputLayoutUsername.errorIconDrawable = null
+                            binding.inputLayoutUsername.isVisible = true
+                            binding.inputLayoutUsername.isVisible = true
+                            binding.clearUsernameTextButton.isVisible = true
+                        }
+                    }
                     updateUsernameField()
                     findDuplicate()
                     setSaveButtonState()
@@ -179,10 +199,14 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login), MenuProvider {
                 override fun afterTextChanged(p: Editable?) {
                     when {
                         p.toString().isEmpty() -> {
+                            validPassword = false
                             passwordChanged = true
                             binding.revealPasswordButton.isVisible = false
                             binding.clearPasswordTextButton.isVisible = false
-                            setPasswordError()
+                            setLayoutError(
+                                context?.getString(R.string.saved_login_password_required),
+                                binding.inputLayoutPassword,
+                            )
                         }
                         p.toString() == oldLogin.password -> {
                             passwordChanged = false
@@ -238,10 +262,6 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login), MenuProvider {
                 // existing login was already a dupe and the username hasn't
                 // changed
                 usernameChanged = oldLogin.username != currentValue
-                validUsername = true
-                layout.error = null
-                layout.errorIconDrawable = null
-                clearButton.isVisible = true
             }
             else -> {
                 // Invalid login because it's a dupe of another one
@@ -264,10 +284,9 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login), MenuProvider {
         setSaveButtonState()
     }
 
-    private fun setPasswordError() {
-        binding.inputLayoutPassword.let { layout ->
-            validPassword = false
-            layout.error = context?.getString(R.string.saved_login_password_required)
+    private fun setLayoutError(error: String?, inputLayout: TextInputLayout) {
+        inputLayout.let { layout ->
+            layout.error = error
             layout.setErrorIconDrawable(R.drawable.mozac_ic_warning_with_bottom_padding)
             layout.setErrorIconTintList(
                 ColorStateList.valueOf(
@@ -285,7 +304,7 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login), MenuProvider {
         inflater.inflate(R.menu.login_save, menu)
     }
 
-    override fun onPrepareOptionsMenu(menu: Menu) {
+    override fun onPrepareMenu(menu: Menu) {
         val saveButton = menu.findItem(R.id.save_login_button)
         val changesMadeWithNoErrors =
             validUsername && validPassword && (usernameChanged || passwordChanged)


### PR DESCRIPTION
The PR fix the bug where the save icon on `Edit login` is always active 

### Issue Screenshots
[fnx-48-issue.webm](https://user-images.githubusercontent.com/93866435/215518790-c37a2e0a-33a0-477e-8c58-42e852393f00.webm)

### Fix Screenshots
[fnx-48-fix.webm](https://user-images.githubusercontent.com/93866435/215518511-8a2b1db2-eabf-4dcc-b4ba-f3d6c8fcedc2.webm)

Pull Request checklist
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Screenshots: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
 
**QA**
- [x] QA Needed

**GitHub Automation**

Fixes #27822
Fixes #27822
Fixes #27822