### PR TITLE
For #1814140 - Added fixed height to the elements in the edit login page

### DIFF
--- a/app/src/main/res/layout/fragment_credit_card_editor.xml
+++ b/app/src/main/res/layout/fragment_credit_card_editor.xml
@@ -7,7 +7,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="16dp">
+    android:layout_marginHorizontal="16dp"
+    android:layout_marginTop="16dp"
+    android:layout_marginBottom="8dp"
+    >
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -31,7 +34,7 @@
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/card_number_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="50dp"
             android:textColor="?attr/textPrimary"
             app:errorEnabled="true"
             app:hintEnabled="false">
@@ -60,7 +63,7 @@
             style="@style/CaptionTextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
+            android:layout_marginTop="8dp"
             android:gravity="center_vertical"
             android:letterSpacing="0.05"
             android:paddingStart="3dp"
@@ -72,8 +75,7 @@
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/name_on_card_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingBottom="11dp"
+            android:layout_height="50dp"
             android:textColor="?attr/textPrimary"
             app:hintEnabled="false">
 
@@ -99,7 +101,7 @@
             style="@style/CaptionTextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
+            android:layout_marginTop="8dp"
             android:gravity="center_vertical"
             android:letterSpacing="0.05"
             android:paddingStart="3dp"
@@ -129,7 +131,7 @@
                 <androidx.appcompat.widget.AppCompatSpinner
                     android:id="@+id/expiry_month_drop_down"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="50dp"
                     tools:listitem="@android:layout/simple_list_item_1" />
 
                 <View
@@ -154,7 +156,7 @@
                 <androidx.appcompat.widget.AppCompatSpinner
                     android:id="@+id/expiry_year_drop_down"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="50dp"
                     tools:listitem="@android:layout/simple_list_item_1" />
 
                 <View
@@ -168,7 +170,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="16dp">
+            android:paddingTop="8dp">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/delete_button"


### PR DESCRIPTION
The PR fixes the "Cancel" and "Save" buttons that are cut off the screen in the landscape when adding a new card   

### Fix description
Changed Textinputlayout height to 50dp from wrap content, and also reduce some Layout margins

### Issue video
[bug.webm](https://user-images.githubusercontent.com/39338964/215788354-3db52024-19c0-465c-939c-c952efcd657c.webm)

### Demo video after fix
[fix.webm](https://user-images.githubusercontent.com/39338964/215786403-797eb806-c31a-4fce-bb31-8abc47a3cce6.webm)

### Pull Request checklist
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots:** This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

**QA**
- [x] QA Needed
### To download an APK when reviewing a PR (after all CI tasks finished running):

1. Click on Checks at the top of the PR page.
2. Click on the firefoxci-taskcluster group on the left to expand all tasks.
3. Click on the build-debug task.
4. Click on View task in Taskcluster in the new DETAILS section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #1814140