### PR TITLE
Bug 1811537 - Add secret setting allowing to overwrite the `country` and `city` parameters for Pocket sponsored stories

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -413,7 +413,11 @@ class Core(
                 appId = BuildConfig.POCKET_CONSUMER_KEY,
             ),
             sponsoredStoriesParams = if (context.settings().useCustomConfigurationForSponsoredStories) {
-                PocketStoriesRequestConfig(context.settings().pocketSponsoredStoriesSiteId)
+                PocketStoriesRequestConfig(
+                    context.settings().pocketSponsoredStoriesSiteId,
+                    context.settings().pocketSponsoredStoriesCountry,
+                    context.settings().pocketSponsoredStoriesCity,
+                )
             } else {
                 PocketStoriesRequestConfig()
             },

--- a/app/src/main/java/org/mozilla/fenix/settings/SponsoredStoriesSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SponsoredStoriesSettingsFragment.kt
@@ -34,5 +34,21 @@ class SponsoredStoriesSettingsFragment : PreferenceFragmentCompat() {
                 true
             }
         }
+
+        requirePreference<EditTextPreference>(R.string.pref_key_custom_sponsored_stories_country).apply {
+            isVisible = Config.channel.isNightlyOrDebug
+            onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+                context.settings().pocketSponsoredStoriesCountry = (newValue as String)
+                true
+            }
+        }
+
+        requirePreference<EditTextPreference>(R.string.pref_key_custom_sponsored_stories_city).apply {
+            isVisible = Config.channel.isNightlyOrDebug
+            onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+                context.settings().pocketSponsoredStoriesCity = (newValue as String)
+                true
+            }
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1473,6 +1473,22 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
+     * Country parameter used to set the spoc content.
+     */
+    var pocketSponsoredStoriesCountry by stringPreference(
+        appContext.getPreferenceKey(R.string.pref_key_custom_sponsored_stories_country),
+        default = "",
+    )
+
+    /**
+     * City parameter used to set the spoc content.
+     */
+    var pocketSponsoredStoriesCity by stringPreference(
+        appContext.getPreferenceKey(R.string.pref_key_custom_sponsored_stories_city),
+        default = "",
+    )
+
+    /**
      * Indicates if the Contile functionality should be visible.
      */
     var showContileFeature by booleanPreference(

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -320,6 +320,8 @@
     <string name="pref_key_custom_sponsored_stories_parameters" translatable="false">pref_key_custom_sponsored_stories_parameters</string>
     <string name="pref_key_custom_sponsored_stories_parameters_enabled" translatable="false">pref_key_custom_sponsored_stories_parameters_enabled</string>
     <string name="pref_key_custom_sponsored_stories_site_id" translatable="false">pref_key_custom_sponsored_stories_site_id</string>
+    <string name="pref_key_custom_sponsored_stories_country" translatable="false">pref_key_custom_sponsored_stories_country</string>
+    <string name="pref_key_custom_sponsored_stories_city" translatable="false">pref_key_custom_sponsored_stories_city</string>
 
     <!-- Growth Data -->
     <string name="pref_key_growth_set_as_default" translatable="false">pref_key_growth_set_as_default</string>

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -54,6 +54,10 @@
     <string name="preferences_debug_settings_custom_sponsored_stories_parameters_enabled" translatable="false">Enable custom Pocket sponsored stories parameters (requires restart)</string>
     <!-- Label for custom Pocket sponsored stories site id setting -->
     <string name="preferences_debug_settings_custom_sponsored_stories_parameters_site" translatable="false">Site parameter</string>
+    <!-- Label for custom Pocket sponsored stories country parameter -->
+    <string name="preferences_debug_settings_custom_sponsored_stories_country" translatable="false">Country parameter</string>
+    <!-- Label for custom Pocket sponsored stories city parameter -->
+    <string name="preferences_debug_settings_custom_sponsored_stories_city" translatable="false">City parameter</string>
     <!-- Title of preference for sync debugging (only shown in the when the secret debug menu is enabled) -->
     <string name="preferences_sync_debug">Sync Debug</string>
     <!-- Preference to override the Push server -->

--- a/app/src/main/res/xml/sponsored_stories_settings.xml
+++ b/app/src/main/res/xml/sponsored_stories_settings.xml
@@ -15,4 +15,18 @@
         android:title="@string/preferences_debug_settings_custom_sponsored_stories_parameters_site"
         app:iconSpaceReserved="false"
         app:useSimpleSummaryProvider="true" />
+    <EditTextPreference
+        android:dependency="@string/pref_key_custom_sponsored_stories_parameters_enabled"
+        android:key="@string/pref_key_custom_sponsored_stories_country"
+        android:title="@string/preferences_debug_settings_custom_sponsored_stories_country"
+        android:inputType="text"
+        app:useSimpleSummaryProvider="true"
+        app:iconSpaceReserved="false" />
+    <EditTextPreference
+        android:dependency="@string/pref_key_custom_sponsored_stories_parameters_enabled"
+        android:key="@string/pref_key_custom_sponsored_stories_city"
+        android:title="@string/preferences_debug_settings_custom_sponsored_stories_city"
+        android:inputType="text"
+        app:useSimpleSummaryProvider="true"
+        app:iconSpaceReserved="false" />
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
For 1811537 - Add secret setting allowing to overwrite the `country` and `city` parameters for Pocket sponsored stories.

https://user-images.githubusercontent.com/35462038/217459793-4f3cd12f-1e1f-4260-9868-21b94b83c372.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #28791