### PR TITLE
Bug 1807283 - Fix flakiness in verifyJumpBackInSectionTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -140,12 +140,13 @@ class HomeScreenTest {
             verifyJumpBackInShowAllButton()
         }.clickJumpBackInShowAllButton {
             verifyExistingOpenTabs(firstWebPage.title)
-        }.closeTabDrawer() {
+        }.closeTabDrawer {
         }
         homeScreen {
         }.clickJumpBackInItemWithTitle(firstWebPage.title) {
             verifyUrl(firstWebPage.url.toString())
             clickLinkMatchingText("Link 1")
+            verifyPageContent(secondWebPage.content)
         }.goToHomescreen {
             verifyJumpBackInSectionIsDisplayed()
             verifyJumpBackInItemTitle(secondWebPage.title)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -286,7 +286,10 @@ class HomeScreenRobot {
     }
     fun verifyTopSiteContextMenuItems() = assertTopSiteContextMenuItems()
 
-    fun verifyJumpBackInSectionIsDisplayed() = assertJumpBackInSectionIsDisplayed()
+    fun verifyJumpBackInSectionIsDisplayed() {
+        scrollToElementByText(getStringResource(R.string.recent_tabs_header))
+        assertTrue(jumpBackInSection().waitForExists(waitingTime))
+    }
     fun verifyJumpBackInSectionIsNotDisplayed() = assertJumpBackInSectionIsNotDisplayed()
     fun verifyJumpBackInItemTitle(itemTitle: String) = assertJumpBackInItemTitle(itemTitle)
     fun verifyJumpBackInItemWithUrl(itemUrl: String) = assertJumpBackInItemWithUrl(itemUrl)
@@ -985,8 +988,6 @@ private fun assertTopSiteContextMenuItems() {
         waitingTime,
     )
 }
-
-private fun assertJumpBackInSectionIsDisplayed() = assertTrue(jumpBackInSection().waitForExists(waitingTime))
 
 private fun assertJumpBackInSectionIsNotDisplayed() = assertFalse(jumpBackInSection().waitForExists(waitingTimeShort))
 


### PR DESCRIPTION
Fixed scrolling issue and delays in updating the home screen. Ran 50 times on Firebase https://github.com/mozilla-mobile/fenix/runs/11084221022 all green.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
