### PR TITLE
For #1813787 - Hide `Add to shortcuts` menu entry if Shortcuts are disabled on the Homepage

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -70,6 +70,7 @@ open class DefaultToolbarMenu(
 
     private val shouldDeleteDataOnQuit = context.settings().shouldDeleteBrowsingDataOnQuit
     private val shouldUseBottomToolbar = context.settings().shouldUseBottomToolbar
+    private val shouldShowTopPickOption = context.settings().showTopSitesFeature
     private val accountManager = FenixAccountManager(context)
 
     private val selectedSession: TabSessionState?
@@ -379,7 +380,7 @@ open class DefaultToolbarMenu(
                 BrowserMenuDivider(),
                 addToHomeScreenItem.apply { visible = ::canAddToHomescreen },
                 installToHomescreen.apply { visible = ::canInstall },
-                addRemoveTopSitesItem,
+                if (shouldShowTopPickOption) addRemoveTopSitesItem else null,
                 saveToCollectionItem,
                 BrowserMenuDivider(),
                 settingsItem,


### PR DESCRIPTION
"Add to shortcuts" menu entry should be hidden if Shortcuts are disabled on the HomepageScreens need refactor.

- ShortScreen
- HomeScreen

### Issue Screenshots
[fnx-54-issue.webm](https://user-images.githubusercontent.com/20729878/216297805-d9dd8d94-c534-4c8e-a5bd-aa13189e9652.webm)



### Fix Screenshots

[fnx-54-fixed.webm](https://user-images.githubusercontent.com/20729878/216386701-74f89fb2-517a-442e-ba3a-8637cbc4a2a6.webm)


Pull Request checklist
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Screenshots: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
 
**QA**
- [x] QA Needed

**GitHub Automation**
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1813787
Fixes #1813787