### PR TITLE
Bug 1814410: Unified search migrate to general search engine after search engine list loads

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -248,7 +248,6 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
         setupLeakCanary()
         startMetricsIfEnabled()
         setupPush()
-        migrateTopicSpecificSearchEngines()
 
         visibilityLifecycleCallback = VisibilityLifecycleCallback(getSystemService())
         registerActivityLifecycleCallbacks(visibilityLifecycleCallback)
@@ -792,6 +791,8 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
                         name.set("custom")
                     }
                 }
+
+                migrateTopicSpecificSearchEngines()
             }
         }
     }


### PR DESCRIPTION
It seems like the previous call for the migration was not consistently working, on nightly the searchEngines list was not completely loaded when calling the migration. The method call was moved to `waitForSelectedOrDefaultSearchEngine` since here we know for sure that the list is loaded (Kudos to @Mugurell for helping me with this). Since unified search will require a restart, the migration does not happen immediately after activating the feature, but only when manually restarting the app.

Video for behavior when restarting:

https://user-images.githubusercontent.com/32488956/217195878-80818cf2-b544-4e3d-8e3b-c511524494e9.mp4

Video for behavior when activating unified search and instead of restarting the app, open the app from the widget:

https://user-images.githubusercontent.com/32488956/217196294-9f6dc251-86a2-4a57-af71-94009c723bfe.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
