### PR TITLE
For #1812196 - Sets height of "Learn more about Sync" in Logins and passwords- Saved logins

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/view/SavedLoginsListView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/view/SavedLoginsListView.kt
@@ -4,11 +4,13 @@
 
 package org.mozilla.fenix.settings.logins.view
 
+import android.content.res.Resources
 import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
+import mozilla.components.support.ktx.android.util.dpToPx
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.ComponentSavedLoginsBinding
 import org.mozilla.fenix.ext.addUnderline
@@ -38,6 +40,7 @@ class SavedLoginsListView(
         }
 
         with(binding.savedPasswordsEmptyLearnMore) {
+            height = 48.dpToPx(Resources.getSystem().displayMetrics)
             movementMethod = LinkMovementMethod.getInstance()
             addUnderline()
             setOnClickListener { interactor.onLearnMoreClicked() }


### PR DESCRIPTION
The PR increases the clickable area of the `Learn more about Sync` in the Logins and passwords- Saved logins page

### Issue Screenshots
![FNXOSS-58](https://user-images.githubusercontent.com/2725300/216322497-9281abd3-c1c6-46d7-afd9-1c11cd51adbe.gif)

### Fix Screenshots
[FNXOSS-56 FIX.webm](https://user-images.githubusercontent.com/2725300/216570647-86dac6d5-d6f0-4c04-9af3-f61e832b9252.webm)

Pull Request checklist
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Screenshots: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
 
**QA**
- [x] QA Needed

**GitHub Automation**


Fixes #1812196