### PR TITLE
Bug 1814206 - Simplify the parameters of `DefaultTabsTrayController`

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
@@ -32,6 +32,7 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.ext.DEFAULT_ACTIVE_DAYS
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.potentialInactiveTabs
 import org.mozilla.fenix.home.HomeFragment
 import org.mozilla.fenix.selection.SelectionHolder
@@ -187,21 +188,22 @@ interface TabsTrayController : SyncedTabsController, InactiveTabsController, Tab
 @Suppress("TooManyFunctions", "LongParameterList")
 class DefaultTabsTrayController(
     private val activity: HomeActivity,
-    private val appStore: AppStore,
     private val tabsTrayStore: TabsTrayStore,
-    private val browserStore: BrowserStore,
-    private val settings: Settings,
-    private val browsingModeManager: BrowsingModeManager,
     private val navController: NavController,
     private val navigateToHomeAndDeleteSession: (String) -> Unit,
-    private val profiler: Profiler?,
     private val navigationInteractor: NavigationInteractor,
-    private val tabsUseCases: TabsUseCases,
     private val selectTabPosition: (Int, Boolean) -> Unit,
     private val dismissTray: () -> Unit,
     private val showUndoSnackbarForTab: (Boolean) -> Unit,
     internal val showCancelledDownloadWarning: (downloadCount: Int, tabId: String?, source: String?) -> Unit,
 ) : TabsTrayController {
+
+    private val appStore: AppStore = activity.components.appStore
+    private val browserStore: BrowserStore = activity.components.core.store
+    private val settings: Settings = activity.components.settings
+    private val browsingModeManager: BrowsingModeManager = activity.browsingModeManager
+    private val profiler: Profiler? = activity.components.core.engine.profiler
+    private val tabsUseCases: TabsUseCases = activity.components.useCases.tabsUseCases
 
     override fun handleNormalTabsFabClick() {
         openNewTab(isPrivate = false)

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -206,16 +206,10 @@ class TabsTrayFragment : AppCompatDialogFragment() {
 
         tabsTrayController = DefaultTabsTrayController(
             activity = activity,
-            appStore = requireComponents.appStore,
             tabsTrayStore = tabsTrayStore,
-            browserStore = requireComponents.core.store,
-            settings = requireContext().settings(),
-            browsingModeManager = activity.browsingModeManager,
             navController = findNavController(),
             navigateToHomeAndDeleteSession = ::navigateToHomeAndDeleteSession,
             navigationInteractor = navigationInteractor,
-            profiler = requireComponents.core.engine.profiler,
-            tabsUseCases = requireComponents.useCases.tabsUseCases,
             selectTabPosition = ::selectTabPosition,
             dismissTray = ::dismissTabsTray,
             showUndoSnackbarForTab = ::showUndoSnackbarForTab,

--- a/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
@@ -50,6 +50,7 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.maxActiveTime
 import org.mozilla.fenix.ext.potentialInactiveTabs
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
@@ -786,18 +787,19 @@ class DefaultTabsTrayControllerTest {
         showUndoSnackbarForTab: (Boolean) -> Unit = { _ -> },
         showCancelledDownloadWarning: (Int, String?, String?) -> Unit = { _, _, _ -> },
     ): DefaultTabsTrayController {
+        every { activity.components.appStore } returns appStore
+        every { activity.components.core.store } returns browserStore
+        every { activity.components.settings } returns settings
+        every { activity.browsingModeManager } returns browsingModeManager
+        every { activity.components.core.engine.profiler } returns profiler
+        every { activity.components.useCases.tabsUseCases } returns tabsUseCases
+
         return DefaultTabsTrayController(
             activity = activity,
-            appStore = appStore,
             tabsTrayStore = trayStore,
-            browserStore = browserStore,
-            settings = settings,
-            browsingModeManager = browsingModeManager,
             navController = navController,
             navigateToHomeAndDeleteSession = navigateToHomeAndDeleteSession,
-            profiler = profiler,
             navigationInteractor = navigationInteractor,
-            tabsUseCases = tabsUseCases,
             selectTabPosition = selectTabPosition,
             dismissTray = dismissTray,
             showUndoSnackbarForTab = showUndoSnackbarForTab,


### PR DESCRIPTION
So sadly, only 6 of the parameters could be refactored out of the constructor at this time. We may be able to change this later if we do a sweeping refactor of `TabsTrayFragment`, as some of the remaining parameters are dependent upon logic passed-in as navigation arguments.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
