### PR TITLE
Bug 1813694: Update strings for history group section

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
@@ -314,9 +314,9 @@ private fun RecentlyVisitedCaption(
     modifier: Modifier,
 ) {
     val stringId = if (count == 1) {
-        R.string.history_search_group_site
+        R.string.history_search_group_site_1
     } else {
-        R.string.history_search_group_sites
+        R.string.history_search_group_sites_1
     }
 
     Text(

--- a/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
@@ -73,9 +73,9 @@ class HistoryListItemViewHolder(
             is History.Group -> {
                 val numChildren = item.items.size - groupPendingDeletionCount
                 val stringId = if (numChildren == 1) {
-                    R.string.history_search_group_site
+                    R.string.history_search_group_site_1
                 } else {
-                    R.string.history_search_group_sites
+                    R.string.history_search_group_sites_1
                 }
                 String.format(itemView.context.getString(stringId), numChildren)
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -700,10 +700,16 @@
 
     <!-- Text to show users they have one site in the history group section of the History fragment.
     %d is a placeholder for the number of sites in the group. -->
-    <string name="history_search_group_site">%d site</string>
+    <string name="history_search_group_site" moz:RemovedIn="111" tools:ignore="UnusedResources">%d site</string>
+    <!-- Text to show users they have one page in the history group section of the History fragment.
+    %d is a placeholder for the number of pages in the group. -->
+    <string name="history_search_group_site_1">%d page</string>
     <!-- Text to show users they have multiple sites in the history group section of the History fragment.
     %d is a placeholder for the number of sites in the group. -->
-    <string name="history_search_group_sites">%d sites</string>
+    <string name="history_search_group_sites" moz:RemovedIn="111" tools:ignore="UnusedResources">%d sites</string>
+    <!-- Text to show users they have multiple pages in the history group section of the History fragment.
+    %d is a placeholder for the number of pages in the group. -->
+    <string name="history_search_group_sites_1">%d pages</string>
 
     <!-- Option in library for Recently Closed Tabs -->
     <string name="library_recently_closed_tabs">Recently closed tabs</string>


### PR DESCRIPTION
Replaced `sites` string with `pages` 

<img width="464" alt="Screenshot 2023-02-07 at 14 59 36" src="https://user-images.githubusercontent.com/32488956/217252721-f5e7b3f3-a2c4-43d6-a2ce-ff35daecc310.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
