### PR TITLE
Bug 1815504  - Convert existing legacy-arm Task to soft dependency

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -36,8 +36,4 @@ jobs:
           type: decision-task
           treeherder-symbol: legacy-api-ui
           target-tasks-method: legacy_api_ui_tests
-      when:
-          - {hour: 9, minute: 0}
-          - {hour: 12, minute: 0}
-          - {hour: 18, minute: 0}
-          - {hour: 22, minute: 0}
+      when: [] # unscheduled

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -151,8 +151,9 @@ tasks:
     legacy-arm:
         attributes:
             legacy: true
-        description: Run select UI tests on older Android API on cron
-        run-on-tasks-for: []
+            code-review: false
+        description: Run select UI tests on legacy Android devices and API levels
+        run-on-tasks-for: [github-push]
         run-on-git-branches: [main]
         run:
             commands:


### PR DESCRIPTION
We would like to run our current test `Task` `legacy-arm` on `github-push` but not be blocking the `complete` `task`. We can try setting the `code-review: false` attribute on the `Task`. From then, we can turn off the `Cron` for this `Task`.