### PR TITLE
Bug 1812251 - making the URL icons from the Bookmarks page larger

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -13,7 +13,7 @@
     <dimen name="mozac_browser_menu2_corner_radius">8dp</dimen>
     <dimen name="library_item_height">56dp</dimen>
     <dimen name="library_item_icon_margin_horizontal">16dp</dimen>
-    <dimen name="history_favicon_width_height">40dp</dimen>
+    <dimen name="history_favicon_width_height">48dp</dimen>
     <dimen name="tab_corner_radius">8dp</dimen>
     <dimen name="preference_icon_drawable_size">24dp</dimen>
     <dimen name="search_bar_search_engine_icon_padding">12dp</dimen>


### PR DESCRIPTION
The PR makes the URL icons from the Bookmarks page larger

### Steps to test

1. Have Google Accessibility Scanner installed.
2. Save some bookmarks.
3. Open "Bookmarks" from the three-dot menu.
4. Using the Accessibility Scanner, scan the "Bookmarks" page.

### Issue Screenshots
![URLicon](https://user-images.githubusercontent.com/2725300/216988098-a5a41bd5-6d38-4799-9d1d-7ddd7b02ea96.png)


### Fix Screenshots
![66 Fix](https://user-images.githubusercontent.com/2725300/217162540-0a4e8284-2d58-4963-8ba8-2a504ebce69e.png)


Pull Request checklist
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Screenshots: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
 
**QA**
- [x] QA Needed

**GitHub Automation**

