### PR TITLE
Bug 1815160 - Add sponsored story id to home_recs_spoc_shown and home_recs_spoc_clicked

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -6107,6 +6107,10 @@ pocket:
     description: |
       User tapped a Pocket sponsored story to be opened.
     extra_keys:
+      spoc_id:
+        type: string
+        description: |
+          Id of the shown sponsored story.
       times_shown:
         type: string
         description: |
@@ -6118,7 +6122,9 @@ pocket:
           Uses the [row x column] matrix notation.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/25401
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1815160
     data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/28796#issuecomment-1422818844
       - https://github.com/mozilla-mobile/fenix/pull/25418#issuecomment-1163390855
       - https://github.com/mozilla-mobile/fenix/pull/26184#issuecomment-1194744884
     data_sensitivity:
@@ -6157,6 +6163,10 @@ pocket:
       A particular Pocket sponsored story was visible more than 50%
       on the homescreen.
     extra_keys:
+      spoc_id:
+        type: string
+        description: |
+          Id of the shown sponsored story.
       times_shown:
         type: string
         description: |
@@ -6168,7 +6178,9 @@ pocket:
           Uses the [row x column] matrix notation.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/25401
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1815160
     data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/28796#issuecomment-1422818844
       - https://github.com/mozilla-mobile/fenix/pull/25418#issuecomment-1163390855
       - https://github.com/mozilla-mobile/fenix/pull/26184#issuecomment-1194744884
     data_sensitivity:

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesController.kt
@@ -85,6 +85,7 @@ internal class DefaultPocketStoriesController(
             is PocketSponsoredStory -> {
                 Pocket.homeRecsSpocShown.record(
                     Pocket.HomeRecsSpocShownExtra(
+                        spocId = storyShown.id.toString(),
                         position = "${storyPosition.first}x${storyPosition.second}",
                         timesShown = storyShown.getCurrentFlightImpressions().size.inc().toString(),
                     ),
@@ -162,6 +163,7 @@ internal class DefaultPocketStoriesController(
             is PocketSponsoredStory -> {
                 Pocket.homeRecsSpocClicked.record(
                     Pocket.HomeRecsSpocClickedExtra(
+                        spocId = storyClicked.id.toString(),
                         position = "${storyPosition.first}x${storyPosition.second}",
                         timesShown = storyClicked.getCurrentFlightImpressions().size.inc().toString(),
                     ),

--- a/app/src/test/java/org/mozilla/fenix/home/pocket/DefaultPocketStoriesControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/pocket/DefaultPocketStoriesControllerTest.kt
@@ -177,6 +177,7 @@ class DefaultPocketStoriesControllerTest {
         val storyShown: PocketSponsoredStory = mockk {
             every { shim.click } returns "testClickShim"
             every { shim.impression } returns "testImpressionShim"
+            every { id } returns 123
         }
         var wasPingSent = false
         mockkStatic("mozilla.components.service.pocket.ext.PocketStoryKt") {
@@ -195,6 +196,7 @@ class DefaultPocketStoriesControllerTest {
             assertNotNull(Pocket.homeRecsSpocShown.testGetValue())
             assertEquals(1, Pocket.homeRecsSpocShown.testGetValue()!!.size)
             val data = Pocket.homeRecsSpocShown.testGetValue()!!.single().extra
+            assertEquals("123", data?.entries?.first { it.key == "spoc_id" }?.value)
             assertEquals("1x2", data?.entries?.first { it.key == "position" }?.value)
             assertEquals("4", data?.entries?.first { it.key == "times_shown" }?.value)
             assertTrue(wasPingSent)
@@ -279,6 +281,7 @@ class DefaultPocketStoriesControllerTest {
             assertNotNull(Pocket.homeRecsSpocClicked.testGetValue())
             assertEquals(1, Pocket.homeRecsSpocClicked.testGetValue()!!.size)
             val data = Pocket.homeRecsSpocClicked.testGetValue()!!.single().extra
+            assertEquals("7", data?.entries?.first { it.key == "spoc_id" }?.value)
             assertEquals("2x3", data?.entries?.first { it.key == "position" }?.value)
             assertEquals("3", data?.entries?.first { it.key == "times_shown" }?.value)
             assertTrue(wasPingSent)


### PR DESCRIPTION
Added sponsored story id to home_recs_spoc_shown and home_recs_spoc_clicked.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
