### PR TITLE
Bug 1814506 - Add unit tests to cover multi selection of tabs

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
@@ -54,6 +54,7 @@ import org.mozilla.fenix.ext.maxActiveTime
 import org.mozilla.fenix.ext.potentialInactiveTabs
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.HomeFragment
+import org.mozilla.fenix.selection.SelectionHolder
 import org.mozilla.fenix.utils.Settings
 import java.util.concurrent.TimeUnit
 
@@ -541,6 +542,91 @@ class DefaultTabsTrayControllerTest {
                 from = BrowserDirection.FromTabsTray,
             )
         }
+    }
+
+    @Test
+    fun `GIVEN no tabs selected and the user is not in multi select mode WHEN the user long taps a tab THEN that tab will become selected`() {
+        trayStore = TabsTrayStore()
+        val selectionHolder: SelectionHolder<TabSessionState> = mockk {
+            every { selectedItems } returns emptySet()
+        }
+        val controller = spyk(createController())
+        val tab1 = TabSessionState(
+            id = "1",
+            content = ContentState(
+                url = "www.mozilla.com",
+            ),
+        )
+        val tab2 = TabSessionState(
+            id = "2",
+            content = ContentState(
+                url = "www.google.com",
+            ),
+        )
+        trayStore.dispatch(TabsTrayAction.ExitSelectMode)
+        trayStore.waitUntilIdle()
+
+        controller.handleMultiSelectClicked(tab1, selectionHolder, "Tabs tray")
+        verify(exactly = 1) { controller.handleTabSelected(tab1, "Tabs tray") }
+
+        controller.handleMultiSelectClicked(tab2, selectionHolder, "Tabs tray")
+        verify(exactly = 1) { controller.handleTabSelected(tab2, "Tabs tray") }
+    }
+
+    @Test
+    fun `GIVEN the user is in multi select mode and a tab is selected WHEN the user taps the selected tab THEN the tab will become unselected`() {
+        trayStore = TabsTrayStore()
+        val tab1 = TabSessionState(
+            id = "1",
+            content = ContentState(
+                url = "www.mozilla.com",
+            ),
+        )
+        val tab2 = TabSessionState(
+            id = "2",
+            content = ContentState(
+                url = "www.google.com",
+            ),
+        )
+        val selectionHolder: SelectionHolder<TabSessionState> = mockk {
+            every { selectedItems } returns setOf(tab1, tab2)
+        }
+        val controller = spyk(createController())
+        trayStore.dispatch(TabsTrayAction.EnterSelectMode)
+        trayStore.waitUntilIdle()
+
+        controller.handleMultiSelectClicked(tab1, selectionHolder, "Tabs tray")
+        verify(exactly = 1) { controller.handleTabUnselected(tab1) }
+
+        controller.handleMultiSelectClicked(tab2, selectionHolder, "Tabs tray")
+        verify(exactly = 1) { controller.handleTabUnselected(tab2) }
+    }
+
+    @Test
+    fun `GIVEN at least a tab is selected and the user is in multi select mode WHEN the user taps a tab THEN that tab will become selected`() {
+        trayStore = spyk(TabsTrayStore())
+        trayStore.dispatch(TabsTrayAction.EnterSelectMode)
+        trayStore.waitUntilIdle()
+        val controller = spyk(createController())
+        val tab1 = TabSessionState(
+            id = "1",
+            content = ContentState(
+                url = "www.mozilla.com",
+            ),
+        )
+        val selectionHolder: SelectionHolder<TabSessionState> = mockk {
+            every { selectedItems } returns setOf(tab1)
+        }
+        val tab2 = TabSessionState(
+            id = "2",
+            content = ContentState(
+                url = "www.google.com",
+            ),
+        )
+
+        controller.handleMultiSelectClicked(tab2, selectionHolder, "Tabs tray")
+
+        verify(exactly = 1) { trayStore.dispatch(TabsTrayAction.AddSelectTab(tab2)) }
     }
 
     @Test


### PR DESCRIPTION
Three new unit tests have been added to cover cases when multiple tabs are selected or unselected.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
