### PR TITLE
Bug 1812175 - Turn on Sync page - Touch target suggestion is displayed

### DIFF
--- a/app/src/main/res/layout/fragment_turn_on_sync.xml
+++ b/app/src/main/res/layout/fragment_turn_on_sync.xml
@@ -78,6 +78,7 @@
             android:id="@+id/createAccount"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:minHeight="@dimen/accessibility_min_height"
             android:gravity="center"
             android:textAppearance="@style/Body14TextStyle"
             app:layout_constraintTop_toBottomOf="@id/signInEmailButton"


### PR DESCRIPTION
The PR makes the `Turn on Sync page` touch target area larger

### Steps to test

1. Have the Accessibility scanner installed and opened.
2. Go to the main menu and tap on "Sign in to sync" option
3. Scan the page


### Issue Screenshots
![issue](https://user-images.githubusercontent.com/2725300/217442092-e3f2ab84-b248-4454-ae86-5165576a693c.jpeg)

### Fix Screenshots
![69 fix](https://user-images.githubusercontent.com/2725300/217529189-dc2fbfb8-909e-4976-9908-1dc8c525b9c1.png)



Pull Request checklist
 - [x] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Screenshots: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
 
**QA**
- [x] QA Needed

**GitHub Automation**


