### PR TITLE
Bug #1812430 - No success pop-up/ snackbar is displayed after adding manually a login

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/controller/SavedLoginsStorageController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/controller/SavedLoginsStorageController.kt
@@ -21,6 +21,7 @@ import mozilla.components.service.sync.logins.LoginsApiException
 import mozilla.components.service.sync.logins.NoSuchRecordException
 import mozilla.components.service.sync.logins.SyncableLoginsStorage
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.settings.logins.LoginsAction
 import org.mozilla.fenix.settings.logins.LoginsFragmentStore
 import org.mozilla.fenix.settings.logins.fragment.AddLoginFragmentDirections
@@ -39,6 +40,7 @@ open class SavedLoginsStorageController(
     private val loginsFragmentStore: LoginsFragmentStore,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val clipboardHandler: ClipboardHandler,
+    private val snackbar: FenixSnackbar,
 ) {
 
     fun delete(loginId: String) {
@@ -76,6 +78,11 @@ open class SavedLoginsStorageController(
             }
             saveLoginJob?.await()
             withContext(Dispatchers.Main) {
+                snackbar.apply {
+                    setText(context.getString(R.string.new_login_added))
+                    setLength(FenixSnackbar.LENGTH_LONG)
+                    show()
+                }
                 val directions =
                     AddLoginFragmentDirections.actionAddLoginFragmentToSavedLoginsFragment()
                 navController.navigate(directions)

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
@@ -25,9 +25,11 @@ import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.components.support.ktx.android.view.showKeyboard
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentAddLoginBinding
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.redirectToReAuth
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
@@ -76,6 +78,10 @@ class AddLoginFragment : Fragment(R.layout.fragment_add_login), MenuProvider {
                 navController = findNavController(),
                 loginsFragmentStore = loginsFragmentStore,
                 clipboardHandler = requireContext().components.clipboardHandler,
+                snackbar = FenixSnackbar.make(
+                    view = requireActivity().getRootView()!!,
+                    isDisplayedWithBrowserToolbar = false,
+                ),
             ),
         )
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -26,9 +26,11 @@ import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.GleanMetrics.Logins
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentEditLoginBinding
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.redirectToReAuth
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.toEditable
@@ -83,6 +85,10 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login), MenuProvider {
                 navController = findNavController(),
                 loginsFragmentStore = loginsFragmentStore,
                 clipboardHandler = requireContext().components.clipboardHandler,
+                snackbar = FenixSnackbar.make(
+                    view = requireActivity().getRootView()!!,
+                    isDisplayedWithBrowserToolbar = false,
+                ),
             ),
         )
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/LoginDetailFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/LoginDetailFragment.kt
@@ -32,6 +32,7 @@ import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentLoginDetailBinding
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.ext.redirectToReAuth
 import org.mozilla.fenix.ext.settings
@@ -90,6 +91,10 @@ class LoginDetailFragment : SecureFragment(R.layout.fragment_login_detail), Menu
                 navController = findNavController(),
                 loginsFragmentStore = savedLoginsStore,
                 clipboardHandler = requireContext().components.clipboardHandler,
+                snackbar = FenixSnackbar.make(
+                    view = requireActivity().getRootView()!!,
+                    isDisplayedWithBrowserToolbar = false,
+                ),
             ),
         )
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
@@ -28,9 +28,11 @@ import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.SecureFragment
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentSavedLoginsBinding
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.redirectToReAuth
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
@@ -89,6 +91,10 @@ class SavedLoginsFragment : SecureFragment(), MenuProvider {
                 navController = findNavController(),
                 loginsFragmentStore = savedLoginsStore,
                 clipboardHandler = requireContext().components.clipboardHandler,
+                snackbar = FenixSnackbar.make(
+                    view = requireActivity().getRootView()!!,
+                    isDisplayedWithBrowserToolbar = false,
+                ),
             )
 
         savedLoginsInteractor =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1826,6 +1826,8 @@
     <string name="edit">Edit</string>
     <!--  The page title for adding new login. -->
     <string name="add_login">Add new login</string>
+    <!--  Snack message for adding new login. -->
+    <string name="new_login_added">New login added</string>
     <!--  The error message in add/edit login view when password field is blank. -->
     <string name="saved_login_password_required">Password required</string>
     <!--  The error message in add login view when username field is blank. -->

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsStorageControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsStorageControllerTest.kt
@@ -10,6 +10,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verifyOrder
 import mozilla.components.concept.storage.EncryptedLogin
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginEntry
@@ -22,9 +23,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.ext.directionsEq
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.settings.logins.controller.SavedLoginsStorageController
+import org.mozilla.fenix.settings.logins.fragment.AddLoginFragmentDirections
 import org.mozilla.fenix.settings.logins.fragment.EditLoginFragmentDirections
 import org.mozilla.fenix.utils.ClipboardHandler
 
@@ -41,6 +44,7 @@ class SavedLoginsStorageControllerTest {
     private val loginsFragmentStore: LoginsFragmentStore = mockk(relaxed = true)
     private val clipboardHandler: ClipboardHandler = mockk(relaxed = true)
     private val loginMock: Login = mockk(relaxed = true)
+    private val snackbar: FenixSnackbar = mockk(relaxed = true)
 
     @Before
     fun setup() {
@@ -57,6 +61,7 @@ class SavedLoginsStorageControllerTest {
             loginsFragmentStore = loginsFragmentStore,
             ioDispatcher = ioDispatcher,
             clipboardHandler = clipboardHandler,
+            snackbar = snackbar,
         )
     }
 
@@ -339,6 +344,26 @@ class SavedLoginsStorageControllerTest {
                     password = "password",
                 ),
             )
+        }
+    }
+
+    @Test
+    fun `WHEN a new login is added THEN a snackbar is shown and navigate to savedLogin`() = runTestOnMain {
+        controller.add(
+            originText = "https://www.firefox.com",
+            usernameText = "username",
+            passwordText = "password",
+        )
+
+        verifyOrder {
+            snackbar.context
+            snackbar.setText(any())
+            snackbar.setLength(FenixSnackbar.LENGTH_LONG)
+            snackbar.show()
+
+            val directions =
+                AddLoginFragmentDirections.actionAddLoginFragmentToSavedLoginsFragment()
+            navController.navigate(directions)
         }
     }
 }


### PR DESCRIPTION
The PR display an snackbar when a new login is added


### Issue video
[fnx-64-issue.webm](https://user-images.githubusercontent.com/93866435/217091674-336975c2-223d-4a57-861d-3483f291a036.webm)


### Demo video after fix
[fnx-64-fix.webm](https://user-images.githubusercontent.com/93866435/217091642-858ddf42-b213-4cdb-b135-ef459b3d743a.webm)


### Pull Request checklist
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots:** This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

**QA**
- [x] QA Needed
### To download an APK when reviewing a PR (after all CI tasks finished running):

1. Click on Checks at the top of the PR page.
2. Click on the firefoxci-taskcluster group on the left to expand all tasks.
3. Click on the build-debug task.
4. Click on View task in Taskcluster in the new DETAILS section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
Used by GitHub Actions.
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1812430
