### PR TITLE
Bug 1809815 - Talkback does not mention "Show all" as a button in the Recently visited section

### DIFF
--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -157,7 +157,7 @@
     <string name="recently_visited_menu_item_remove">Remove</string>
 
     <!-- Content description for the button which navigates the user to show all of their history. -->
-    <string name="past_explorations_show_all_content_description_2">Show all past explorations</string>
+    <string name="past_explorations_show_all_content_description_2">Show all past explorations button</string>
 
     <!-- Browser Fragment -->
     <!-- Content description (not visible, for screen readers etc.): Navigate backward (browsing history) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,7 +152,7 @@
          in the Recently visited section -->
     <string name="recently_visited_menu_item_remove">Remove</string>
     <!-- Content description for the button which navigates the user to show all of their history. -->
-    <string name="past_explorations_show_all_content_description_2">Show all past explorations</string>
+    <string name="past_explorations_show_all_content_description_2">Show all past explorations button</string>
 
     <!-- Browser Fragment -->
     <!-- Content description (not visible, for screen readers etc.): Navigate backward (browsing history) -->


### PR DESCRIPTION
The PR fixes Talkback does not mention "Show all" as a button in the Recently visited section

### Fix description
Appended button to past_explorations_show_all_content_description_2 in strings.xml

### Issue video
https://www.loom.com/share/78849456150c422cb6958b1f69ae0582

### Demo video after fix
https://www.loom.com/share/7470a8dd1f8c48dc89d44c9dff19819d
### Pull Request checklist
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots:** This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

**QA**
- [x] QA Needed
### To download an APK when reviewing a PR (after all CI tasks finished running):

1. Click on Checks at the top of the PR page.
2. Click on the firefoxci-taskcluster group on the left to expand all tasks.
3. Click on the build-debug task.
4. Click on View task in Taskcluster in the new DETAILS section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
Used by GitHub Actions.
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1809815

