### PR TITLE
Bug 1799622 - A password deleted in the password manager, is still visible in the list afterwards

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/controller/SavedLoginsStorageController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/controller/SavedLoginsStorageController.kt
@@ -20,11 +20,11 @@ import mozilla.components.service.sync.logins.InvalidRecordException
 import mozilla.components.service.sync.logins.LoginsApiException
 import mozilla.components.service.sync.logins.NoSuchRecordException
 import mozilla.components.service.sync.logins.SyncableLoginsStorage
-import org.mozilla.fenix.R
 import org.mozilla.fenix.settings.logins.LoginsAction
 import org.mozilla.fenix.settings.logins.LoginsFragmentStore
 import org.mozilla.fenix.settings.logins.fragment.AddLoginFragmentDirections
 import org.mozilla.fenix.settings.logins.fragment.EditLoginFragmentDirections
+import org.mozilla.fenix.settings.logins.fragment.LoginDetailFragmentDirections
 import org.mozilla.fenix.settings.logins.mapToSavedLogin
 import org.mozilla.fenix.utils.ClipboardHandler
 
@@ -49,7 +49,9 @@ open class SavedLoginsStorageController(
             }
             deleteLoginJob?.await()
             withContext(Dispatchers.Main) {
-                navController.popBackStack(R.id.savedLoginsFragment, false)
+                val directions =
+                    LoginDetailFragmentDirections.actionLoginDetailFragmentToSavedLoginsFragment()
+                navController.navigate(directions)
             }
         }
         deleteJob.invokeOnCompletion {

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.widget.FrameLayout
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
@@ -59,6 +60,13 @@ class SavedLoginsFragment : SecureFragment(), MenuProvider {
     override fun onResume() {
         super.onResume()
         initToolbar()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        requireActivity().onBackPressedDispatcher.addCallback(this) {
+            findNavController().popBackStack(R.id.savedLoginsAuthFragment, false)
+        }
     }
 
     override fun onCreateView(

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -472,6 +472,9 @@
             app:destination="@id/editLoginFragment"
             app:popUpTo="@id/editLoginFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_loginDetailFragment_to_savedLoginsFragment"
+            app:destination="@id/savedLoginsFragment" />
     </fragment>
 
     <fragment

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsStorageControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsStorageControllerTest.kt
@@ -26,6 +26,7 @@ import org.mozilla.fenix.ext.directionsEq
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.settings.logins.controller.SavedLoginsStorageController
 import org.mozilla.fenix.settings.logins.fragment.EditLoginFragmentDirections
+import org.mozilla.fenix.settings.logins.fragment.LoginDetailFragmentDirections
 import org.mozilla.fenix.utils.ClipboardHandler
 
 @RunWith(FenixRobolectricTestRunner::class)
@@ -68,7 +69,9 @@ class SavedLoginsStorageControllerTest {
 
         coVerify {
             passwordsStorage.delete(loginId)
-            navController.popBackStack(R.id.savedLoginsFragment, false)
+            val directions =
+                LoginDetailFragmentDirections.actionLoginDetailFragmentToSavedLoginsFragment()
+            navController.navigate(directions)
         }
     }
 


### PR DESCRIPTION
The PR fixes saved Logins not updating immediately a login is deleted

### Fix description
Navigate back to the saved login screen, rather than just popping back stack 

### Issue video
[fnx-58-issue.webm](https://user-images.githubusercontent.com/93866435/216845977-f84bf078-76b6-4fc9-a02b-10649605c509.webm)


### Demo video after fix
[fnx-58-fix.webm](https://user-images.githubusercontent.com/93866435/216846010-0f993584-f300-40cc-a9ff-acc418ce14b7.webm)


### Pull Request checklist
- [ ] **Tests:** This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots:** This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility:** The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

**QA**
- [x] QA Needed
### To download an APK when reviewing a PR (after all CI tasks finished running):

1. Click on Checks at the top of the PR page.
2. Click on the firefoxci-taskcluster group on the left to expand all tasks.
3. Click on the build-debug task.
4. Click on View task in Taskcluster in the new DETAILS section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
Used by GitHub Actions.
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1799622 and https://bugzilla.mozilla.org/show_bug.cgi?id=1812431 (duplicate)











