### PR TITLE
Bug 1814449 - add toggle switch option for open keyboard on new tab

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/TabsSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TabsSettingsFragment.kt
@@ -30,6 +30,9 @@ class TabsSettingsFragment : PreferenceFragmentCompat() {
     private lateinit var inactiveTabsCategory: PreferenceCategory
     private lateinit var inactiveTabs: SwitchPreference
 
+    private lateinit var keyboardFocusOnNewTabCategory: PreferenceCategory
+    private lateinit var keyboardFocusOnNewTab: SwitchPreference
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.tabs_preferences, rootKey)
     }
@@ -68,6 +71,13 @@ class TabsSettingsFragment : PreferenceFragmentCompat() {
         inactiveTabsCategory = requirePreference<PreferenceCategory>(R.string.pref_key_inactive_tabs_category).also {
             it.isEnabled = !(it.context.settings().closeTabsAfterOneDay || it.context.settings().closeTabsAfterOneWeek)
         }
+
+        keyboardFocusOnNewTab = requirePreference<SwitchPreference>(R.string.pref_key_focus_addressbar_on_new_tab).also {
+            it.isChecked = requireContext().settings().shouldOpenKeyboardOnNewTab
+            it.onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
+        keyboardFocusOnNewTabCategory = requirePreference<PreferenceCategory>(R.string.pref_key_focus_addressbar_on_new_tab_category)
 
         listRadioButton.onClickListener(::sendTabViewTelemetry)
         gridRadioButton.onClickListener(::sendTabViewTelemetry)

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
@@ -226,7 +226,7 @@ class DefaultTabsTrayController(
         val startTime = profiler?.getProfilerTime()
         browsingModeManager.mode = BrowsingMode.fromBoolean(isPrivate)
         navController.navigate(
-            TabsTrayFragmentDirections.actionGlobalHome(focusOnAddressBar = true),
+            TabsTrayFragmentDirections.actionGlobalHome(focusOnAddressBar = settings.shouldOpenKeyboardOnNewTab),
         )
         navigationInteractor.onTabTrayDismissed()
         profiler?.addMarker(

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -518,6 +518,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         }
     }
 
+    var shouldOpenKeyboardOnNewTab by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_focus_addressbar_on_new_tab),
+        default = true,
+    )
+
     var shouldUseDarkTheme by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_dark_theme),
         default = false,

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -301,6 +301,9 @@
 
     <string name="pref_key_open_next_tab_desktop_mode" translatable="false">pref_key_open_next_tab_desktop_mode</string>
 
+    <string name="pref_key_focus_addressbar_on_new_tab_category" translatable="false">pref_key_focus_addressbar_on_new_tab_category</string>
+    <string name="pref_key_focus_addressbar_on_new_tab" translatable="false">pref_key_focus_addressbar_on_new_tab</string>
+
     <!-- Pocket -->
     <string name="pref_key_pocket_homescreen_recommendations" translatable="false">pref_key_pocket_homescreen_recommendations</string>
     <string name="pref_key_pocket_sponsored_stories" translatable="false">pref_key_pocket_sponsored_stories</string>

--- a/app/src/main/res/xml/tabs_preferences.xml
+++ b/app/src/main/res/xml/tabs_preferences.xml
@@ -57,4 +57,16 @@
             android:key="@string/pref_key_inactive_tabs"
             android:title="@string/preferences_inactive_tabs_title"/>
     </androidx.preference.PreferenceCategory>
+
+    <androidx.preference.PreferenceCategory
+        android:layout="@layout/preference_cat_style"
+        android:title="Open address bar keyboard for new tabs"
+        android:key="@string/pref_key_focus_addressbar_on_new_tab_category"
+        app:allowDividerAbove="true"
+        app:iconSpaceReserved="false">
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/pref_key_focus_addressbar_on_new_tab"
+            android:title="New tabs will open with address bar in focus and ready to type."/>
+    </androidx.preference.PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
New Tabs Settings page screenshot:
![Screen Shot 2023-02-09 at 4 30 50 PM](https://user-images.githubusercontent.com/1811150/217970047-8d8b118c-a85f-464b-b705-74a9423d1539.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
