### PR TITLE
Bug 1812144 - Homescreen is scrollable even if there is no content

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -126,6 +126,7 @@ import org.mozilla.fenix.perf.MarkersFragmentLifecycleCallbacks
 import org.mozilla.fenix.perf.runBlockingIncrement
 import org.mozilla.fenix.search.toolbar.SearchSelectorMenu
 import org.mozilla.fenix.tabstray.TabsTrayAccessPoint
+import org.mozilla.fenix.utils.AppBarLayoutBehaviorEmptyRecyclerView
 import org.mozilla.fenix.utils.Settings.Companion.TOP_SITES_PROVIDER_MAX_THRESHOLD
 import org.mozilla.fenix.utils.ToolbarPopupWindow
 import org.mozilla.fenix.utils.allowUndo
@@ -503,6 +504,15 @@ class HomeFragment : Fragment() {
         }
     }
 
+    private fun appBarScrollingBehaviorWhenEmptyData() {
+        val appbarLayoutParams = binding.homeAppBar.layoutParams
+        if (appbarLayoutParams is CoordinatorLayout.LayoutParams) {
+            val behavior = AppBarLayoutBehaviorEmptyRecyclerView()
+            appbarLayoutParams.behavior = behavior
+        }
+        binding.homeAppBar.setExpanded(true, true)
+    }
+
     private fun updateLayout(view: View) {
         when (requireContext().settings().toolbarPosition) {
             ToolbarPosition.TOP -> {
@@ -639,6 +649,8 @@ class HomeFragment : Fragment() {
                     updateSearchSelectorMenu(search.searchEngines)
                 }
         }
+
+        appBarScrollingBehaviorWhenEmptyData()
 
         // DO NOT MOVE ANYTHING BELOW THIS addMarker CALL!
         requireComponents.core.engine.profiler?.addMarker(

--- a/app/src/main/java/org/mozilla/fenix/utils/AppBarLayoutBehaviorEmptyRecyclerView.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/AppBarLayoutBehaviorEmptyRecyclerView.kt
@@ -1,0 +1,58 @@
+package org.mozilla.fenix.utils
+
+import android.view.MotionEvent
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.appbar.AppBarLayout
+
+/**
+ * This class is a workaround for the issue described in [https://bugzilla.mozilla.org/show_bug.cgi?id=1812144]
+ * It is used to prevent the app bar from collapsing when the recycler view is empty.
+ */
+@Suppress("MaxLineLength")
+class AppBarLayoutBehaviorEmptyRecyclerView : AppBarLayout.Behavior() {
+    private var isRecyclerViewScrollable = false
+
+    override fun onInterceptTouchEvent(parent: CoordinatorLayout, child: AppBarLayout, ev: MotionEvent): Boolean {
+        return isRecyclerViewScrollable && super.onInterceptTouchEvent(parent, child, ev)
+    }
+
+    override fun onStartNestedScroll(
+        parent: CoordinatorLayout,
+        child: AppBarLayout,
+        directTargetChild: View,
+        target: View,
+        nestedScrollAxes: Int,
+        type: Int,
+    ): Boolean {
+        updateScrollableState(target)
+        return isRecyclerViewScrollable && super.onStartNestedScroll(parent, child, directTargetChild, target, nestedScrollAxes, type)
+    }
+
+    override fun onNestedFling(
+        coordinatorLayout: CoordinatorLayout,
+        child: AppBarLayout,
+        target: View,
+        velocityX: Float,
+        velocityY: Float,
+        consumed: Boolean,
+    ): Boolean {
+        updateScrollableState(target)
+        return isRecyclerViewScrollable && super.onNestedFling(coordinatorLayout, child, target, velocityX, velocityY, consumed)
+    }
+
+    /**
+     * If the child is a [RecyclerView], check if it is scrollable. Otherwise, assume it is scrollable.
+     * This is a workaround because the RecyclerView is having itemCount 2 when all items are disabled,
+     * so we are checking that instead 0 count.
+     */
+    private fun updateScrollableState(child: View) {
+        isRecyclerViewScrollable = if (child is RecyclerView) {
+            val rvAdapter = child.adapter
+            rvAdapter != null && rvAdapter.itemCount > 2
+        } else {
+            true
+        }
+    }
+}


### PR DESCRIPTION
`Homescreen` Appbar is scrollable even if there is no content, from `customize homepage` all options disabled and then the appbar is scrolling if you tap on the bar and scroll up.

- HomeScreen

### Issue Screenshots
[fnx-60-issue.webm](https://user-images.githubusercontent.com/20729878/216605191-1fa098bd-8114-49f6-bc8b-9dac25bdf592.webm)



### Fix Screenshots
[fnx-60-fix.webm](https://user-images.githubusercontent.com/20729878/216927241-45a39792-ec1c-45df-a717-04160546db6a.webm)



Pull Request checklist
 - [ ] Tests: This PR includes thorough tests or an explanation of why it does not
 - [x] Screenshots: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
 - [x] Accessibility: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
 
**QA**
- [x] QA Needed

**GitHub Automation**
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1812144