### PR TITLE
Bug 1816186 - Use detect-only just when we can show the re-engagement dialog

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -132,6 +132,7 @@ import org.mozilla.fenix.settings.TrackingProtectionFragmentDirections
 import org.mozilla.fenix.settings.about.AboutFragmentDirections
 import org.mozilla.fenix.settings.logins.fragment.LoginDetailFragmentDirections
 import org.mozilla.fenix.settings.logins.fragment.SavedLoginsAuthFragmentDirections
+import org.mozilla.fenix.settings.quicksettings.protections.cookiebanners.dialog.CookieBannerReEngagementDialogUtils
 import org.mozilla.fenix.settings.search.AddSearchEngineFragmentDirections
 import org.mozilla.fenix.settings.search.EditCustomSearchEngineFragmentDirections
 import org.mozilla.fenix.settings.studies.StudiesFragmentDirections
@@ -445,6 +446,11 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         // and the user changes the system language
         // More details here: https://github.com/mozilla-mobile/fenix/pull/27793#discussion_r1029892536
         components.core.store.dispatch(SearchAction.RefreshSearchEnginesAction)
+
+        CookieBannerReEngagementDialogUtils.tryToEnableDetectOnlyModeIfNeeded(
+            components.settings,
+            components.core.engine.settings,
+        )
     }
 
     override fun onStart() {

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -140,7 +140,7 @@ class Core(
             cookieBannerHandlingModePrivateBrowsing = context.settings().getCookieBannerHandling(),
             cookieBannerHandlingMode = context.settings().getCookieBannerHandling(),
             cookieBannerHandlingDetectOnlyMode = context.settings()
-                .shouldEnabledCookieBannerDetectOnlyMode(),
+                .shouldShowCookieBannerReEngagementDialog(),
         )
 
         GeckoEngine(

--- a/app/src/main/java/org/mozilla/fenix/settings/CookieBannersFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CookieBannersFragment.kt
@@ -53,7 +53,7 @@ class CookieBannersFragment : PreferenceFragmentCompat() {
                     getEngineSettings().cookieBannerHandlingModePrivateBrowsing = mode
                     getEngineSettings().cookieBannerHandlingMode = mode
                     getEngineSettings().cookieBannerHandlingDetectOnlyMode =
-                        requireContext().settings().shouldEnabledCookieBannerDetectOnlyMode()
+                        requireContext().settings().shouldShowCookieBannerReEngagementDialog()
                     CookieBanners.settingChanged.record(CookieBanners.SettingChangedExtra(metricTag))
                     requireContext().components.useCases.sessionUseCases.reload()
                     return super.onPreferenceChange(preference, newValue)

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/dialog/CookieBannerReEngagementDialog.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/protections/cookiebanners/dialog/CookieBannerReEngagementDialog.kt
@@ -62,13 +62,12 @@ class CookieBannerReEngagementDialog : DialogFragment() {
                         dismiss()
                     },
                     onNotNowButtonClicked = {
+                        disabledCookieBannerHandlingDetectOnlyMode()
                         CookieBanners.notNowReEngagementDialog.record(NoExtras())
                         dismiss()
                     },
                     onCloseButtonClicked = {
-                        getEngineSettings().cookieBannerHandlingDetectOnlyMode = false
-                        getEngineSettings().cookieBannerHandlingModePrivateBrowsing = DISABLED
-                        getEngineSettings().cookieBannerHandlingMode = DISABLED
+                        disabledCookieBannerHandlingDetectOnlyMode()
                         requireContext().settings().userOptOutOfReEngageCookieBannerDialog = true
                         CookieBanners.optOutReEngagementDialog.record(NoExtras())
                         dismiss()
@@ -76,6 +75,12 @@ class CookieBannerReEngagementDialog : DialogFragment() {
                 )
             }
         }
+    }
+
+    private fun disabledCookieBannerHandlingDetectOnlyMode() {
+        getEngineSettings().cookieBannerHandlingDetectOnlyMode = false
+        getEngineSettings().cookieBannerHandlingModePrivateBrowsing = DISABLED
+        getEngineSettings().cookieBannerHandlingMode = DISABLED
     }
 
     private fun getEngineSettings(): Settings {

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -586,10 +586,10 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      * Indicates if we should should show the cookie banner dialog that invites the user to turn-on
      * the setting.
      */
-    fun shouldCookieBannerReEngagementDialog(): Boolean {
+    fun shouldShowCookieBannerReEngagementDialog(): Boolean {
         val shouldShowDialog =
             shouldShowCookieBannerUI && !userOptOutOfReEngageCookieBannerDialog && !shouldUseCookieBanner
-        return if (!shouldShowTotalCookieProtectionCFR && shouldShowDialog) {
+        return if (shouldShowDialog) {
             !cookieBannerDetectedPreviously ||
                 timeNowInMillis() - lastInteractionWithReEngageCookieBannerDialogInMs >= timerForCookieBannerDialog
         } else {
@@ -704,7 +704,10 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     val enabledTotalCookieProtection: Boolean
         get() = Config.channel.isNightlyOrDebug || mr2022Sections[Mr2022Section.TCP_FEATURE] == true
 
-    private val enabledTotalCookieProtectionCFR: Boolean
+    /**
+     * Indicates if the total cookie protection CRF feature is enabled.
+     */
+    val enabledTotalCookieProtectionCFR: Boolean
         get() = Config.channel.isNightlyOrDebug || mr2022Sections[Mr2022Section.TCP_CFR] == true
 
     /**
@@ -1557,24 +1560,12 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     fun getCookieBannerHandling(): CookieBannerHandlingMode {
         return when (shouldUseCookieBanner) {
             true -> CookieBannerHandlingMode.REJECT_ALL
-            false -> if (shouldEnabledCookieBannerDetectOnlyMode()) {
+            false -> if (shouldShowCookieBannerReEngagementDialog()) {
                 CookieBannerHandlingMode.REJECT_ALL
             } else {
                 CookieBannerHandlingMode.DISABLED
             }
         }
-    }
-
-    /**
-     * Indicates if the cookie banner detect only mode should be enabled.
-     */
-    fun shouldEnabledCookieBannerDetectOnlyMode(): Boolean {
-        val tcpCFRAlreadyShown = if (enabledTotalCookieProtectionCFR) {
-            !userOptOutOfReEngageCookieBannerDialog
-        } else {
-            true
-        }
-        return shouldShowCookieBannerUI && tcpCFRAlreadyShown && !shouldUseCookieBanner
     }
 
     var setAsDefaultGrowthSent by booleanPreference(


### PR DESCRIPTION
The platform team brought some concerns of the performance cost of having the detect only mode active while the user can't see re-engagement dialog. They suggested we should keep it active only when the user could see the re-engagement dialog otherwise should be disabled. 

This PR disables the feature when the users can't see the re-engagement dialog until waiting time for next time that the dialog could be seem again.  


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
