### PR TITLE
Bug 1816892 - Update the Private Browsing Mode CFR text

### DIFF
--- a/app/src/main/res/layout/pbm_shortcut_popup.xml
+++ b/app/src/main/res/layout/pbm_shortcut_popup.xml
@@ -31,7 +31,7 @@
             android:layout_marginTop="8dp"
             android:layout_marginEnd="32dp"
             android:lineSpacingExtra="2dp"
-            android:text="@string/private_mode_cfr_message"
+            android:text="@string/private_mode_cfr_message_2"
             android:textColor="@color/fx_mobile_text_color_oncolor_primary"
             app:layout_constraintBottom_toTopOf="@id/cfr_pos_button"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,7 +67,9 @@
     <!-- Text for the main message -->
     <string name="cfr_message" moz:removedIn="109" tools:ignore="UnusedResources">Add a shortcut to open private tabs from your Home screen.</string>
     <!-- Text for the Private mode shortcut CFR message for adding a private mode shortcut to open private tabs from the Home screen -->
-    <string name="private_mode_cfr_message">Launch next private tab in one tap.</string>
+    <string name="private_mode_cfr_message" moz:removedIn="111" tools:ignore="UnusedResources">Launch next private tab in one tap.</string>
+    <!-- Text for the Private mode shortcut CFR message for adding a private mode shortcut to open private tabs from the Home screen -->
+    <string name="private_mode_cfr_message_2">Launch your next private tab in one tap.</string>
     <!-- Text for the positive button -->
     <string name="cfr_pos_button_text" moz:removedIn="109" tools:ignore="UnusedResources">Add shortcut</string>
     <!-- Text for the positive button to accept adding a Private Browsing shortcut to the Home screen -->


### PR DESCRIPTION
Update the Private Browsing Mode CFR text that currently says, “Launch next private tab in one tap.” to say “Launch your next private tab in one tap" [as per the original issue](https://github.com/mozilla-mobile/fenix/issues/28114)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
