### PR TITLE
Bug 1817732 - Do not run any cron-based graphs anymore

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -15,8 +15,7 @@ jobs:
           type: decision-task
           treeherder-symbol: Nt
           target-tasks-method: nightly-test
-      when:
-        - {hour: 5, minute: 0}
+      when: []
     - name: fennec-production
       job:
           type: decision-task
@@ -28,14 +27,10 @@ jobs:
           type: decision-task
           treeherder-symbol: screenshots-D
           target-tasks-method: screenshots
-      when: [{weekday: 'Monday', hour: 10, minute: 0}]
+      when: []
     - name: legacy-api-ui-tests
       job:
           type: decision-task
           treeherder-symbol: legacy-api-ui
           target-tasks-method: legacy_api_ui_tests
-      when:
-          - {hour: 9, minute: 0}
-          - {hour: 12, minute: 0}
-          - {hour: 18, minute: 0}
-          - {hour: 22, minute: 0}
+      when: []


### PR DESCRIPTION
I unarchived the `fenix` repo to get this patch landed. 